### PR TITLE
fix: resolve meals disappearing due to timezone conversion in fetch

### DIFF
--- a/frontend/src/pages/MealPlanner.tsx
+++ b/frontend/src/pages/MealPlanner.tsx
@@ -156,9 +156,9 @@ const MealPlanner: React.FC = () => {
       const token = localStorage.getItem('accessToken');
       const apiBase = import.meta.env.VITE_API_URL || '/api';
       
-      // Format dates for API query
-      const startDate = currentWeekStart.toISOString().split('T')[0];
-      const endDate = addDays(currentWeekStart, 6).toISOString().split('T')[0];
+      // Format dates for API query using formatDateForAPI to avoid timezone issues
+      const startDate = formatDateForAPI(currentWeekStart);
+      const endDate = formatDateForAPI(addDays(currentWeekStart, 6));
       
       const response = await fetch(
         `${apiBase}/meal-plans?startDate=${startDate}&endDate=${endDate}`,


### PR DESCRIPTION
## Critical Bug Fix

Meals were disappearing again because `fetchMealsForWeek` was still using `.toISOString().split('T')[0]` for date formatting, which causes timezone conversion issues.

## Root Cause

When `currentWeekStart` is at midnight local time (e.g., `2026-03-23 00:00:00 CST`), converting to ISO string shifts it to UTC, resulting in the previous day:
- Local: `2026-03-23 00:00:00 CST (UTC-6)`
- ISO: `2026-03-22T06:00:00.000Z`
- Split result: `2026-03-22` ❌ (wrong day!)

This caused the API to query for the wrong week, making all meals disappear.

## Fix

Changed lines 160-161 in `fetchMealsForWeek` to use `formatDateForAPI` helper instead of `.toISOString().split('T')[0]`. This ensures dates are formatted without timezone conversion:

```typescript
// Before (broken):
const startDate = currentWeekStart.toISOString().split('T')[0];
const endDate = addDays(currentWeekStart, 6).toISOString().split('T')[0];

// After (fixed):
const startDate = formatDateForAPI(currentWeekStart);
const endDate = formatDateForAPI(addDays(currentWeekStart, 6));
```

## Testing
- [x] Meals now load correctly for the current week
- [x] No timezone-related date shifts
- [x] Consistent with other date formatting in the file

## Related
- Completes the date handling fixes from PR #34
- Ensures all date operations use consistent formatting