### PR TITLE
fix(ci): resolve E2E test failures in GitHub Actions

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,7 +1,5 @@
 name: E2E Tests
 
-# Root cause fixed: VITE_API_URL now includes /api suffix (was http://localhost:3000,
-# causing CSRF fetch to hit /csrf-token instead of /api/csrf-token — Issue #132)
 on:
   pull_request:
     branches: [main]
@@ -21,6 +19,9 @@ concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest
@@ -28,13 +29,13 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15
+        image: postgres:16
         env:
           POSTGRES_USER: mealplanner
           POSTGRES_PASSWORD: mealplanner_password
           POSTGRES_DB: mealplanner
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U mealplanner -d mealplanner"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -76,6 +77,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-playwright-chromium-
 
+      - name: Install Playwright browsers
+        working-directory: frontend
+        run: pnpm exec playwright install --with-deps chromium
+
       - name: Setup database
         working-directory: backend
         env:
@@ -84,9 +89,10 @@ jobs:
           pnpm prisma generate
           pnpm prisma migrate deploy
           pnpm run prisma:seed
-          # Verify seed data was created
+
           echo "Verifying database seed..."
-          echo "SELECT COUNT(*) as user_count FROM users; SELECT COUNT(*) as recipe_count FROM recipes;" | pnpm prisma db execute --stdin --url "$DATABASE_URL"
+          echo "SELECT COUNT(*) as user_count FROM users; SELECT COUNT(*) as recipe_count FROM recipes;" \
+            | pnpm prisma db execute --stdin --url "$DATABASE_URL"
 
       - name: Start backend server
         working-directory: backend
@@ -96,31 +102,45 @@ jobs:
           JWT_REFRESH_SECRET: test-jwt-refresh-secret-for-ci
           SESSION_SECRET: test-session-secret-for-ci
           NODE_ENV: test
-          E2E_TESTING: true
+          E2E_TESTING: 'true'
           PORT: 3000
           CORS_ORIGIN: http://localhost:5173
         run: |
           pnpm dev > backend.log 2>&1 &
           echo $! > backend.pid
           echo "Backend PID: $(cat backend.pid)"
-          
-          # Wait for backend to be ready with improved health check
+
           echo "Waiting for backend server..."
-          for i in {1..30}; do
+          for i in $(seq 1 45); do
             if curl -f -s http://localhost:3000/health > /dev/null 2>&1; then
-              echo "Backend is ready!"
+              echo "Backend is ready (attempt $i)!"
               curl -s http://localhost:3000/health | jq '.'
               break
             fi
-            if [ $i -eq 30 ]; then
-              echo "Backend failed to start within 60 seconds"
+            if [ "$i" -eq 45 ]; then
+              echo "::error::Backend failed to start within 90 seconds"
               echo "=== Backend logs ==="
               cat backend.log
               exit 1
             fi
-            echo "Attempt $i/30: Backend not ready yet..."
+            echo "Attempt $i/45: Backend not ready yet..."
             sleep 2
           done
+
+          # Verify login endpoint works (catches secret/DB config issues early)
+          echo "Verifying login endpoint..."
+          LOGIN_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST http://localhost:3000/api/auth/login \
+            -H "Content-Type: application/json" \
+            -d '{"email":"test@example.com","password":"TestPass123!"}')
+          HTTP_CODE=$(echo "$LOGIN_RESPONSE" | tail -1)
+          BODY=$(echo "$LOGIN_RESPONSE" | sed '$d')
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Login endpoint returned $HTTP_CODE: $BODY"
+            echo "=== Backend logs ==="
+            cat backend.log
+            exit 1
+          fi
+          echo "Login endpoint verified (HTTP $HTTP_CODE)"
 
       - name: Start frontend server
         working-directory: frontend
@@ -130,16 +150,15 @@ jobs:
           pnpm run dev > frontend.log 2>&1 &
           echo $! > frontend.pid
           echo "Frontend PID: $(cat frontend.pid)"
-          
-          # Wait for frontend to be ready
+
           echo "Waiting for frontend server..."
-          for i in {1..30}; do
+          for i in $(seq 1 30); do
             if curl -f -s http://localhost:5173 > /dev/null 2>&1; then
-              echo "Frontend is ready!"
+              echo "Frontend is ready (attempt $i)!"
               break
             fi
-            if [ $i -eq 30 ]; then
-              echo "Frontend failed to start within 60 seconds"
+            if [ "$i" -eq 30 ]; then
+              echo "::error::Frontend failed to start within 60 seconds"
               echo "=== Frontend logs ==="
               cat frontend.log
               exit 1
@@ -152,14 +171,10 @@ jobs:
         working-directory: frontend
         run: mkdir -p e2e/.auth
 
-      - name: Install Playwright browsers
-        working-directory: frontend
-        run: pnpm exec playwright install --with-deps chromium
-
       - name: Run E2E tests
         working-directory: frontend
         env:
-          E2E_TESTING: true
+          E2E_TESTING: 'true'
           BASE_URL: http://localhost:5173
         run: pnpm run test:e2e
 
@@ -171,11 +186,11 @@ jobs:
           path: frontend/playwright-report/
           retention-days: 30
 
-      - name: Upload test videos
+      - name: Upload test traces
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: test-videos
+          name: test-traces
           path: frontend/test-results/
           retention-days: 7
 
@@ -189,28 +204,37 @@ jobs:
             frontend/frontend.log
           retention-days: 7
 
+      - name: Test summary
+        if: always()
+        working-directory: frontend
+        run: |
+          if [ -f test-results/results.json ]; then
+            echo "### E2E Test Results" >> $GITHUB_STEP_SUMMARY
+            PASSED=$(jq '[.suites[].specs[] | select(.ok == true)] | length' test-results/results.json 2>/dev/null || echo "?")
+            FAILED=$(jq '[.suites[].specs[] | select(.ok == false)] | length' test-results/results.json 2>/dev/null || echo "?")
+            echo "| Status | Count |" >> $GITHUB_STEP_SUMMARY
+            echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
+            echo "| Passed | $PASSED |" >> $GITHUB_STEP_SUMMARY
+            echo "| Failed | $FAILED |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### E2E Test Results" >> $GITHUB_STEP_SUMMARY
+            echo "No test results found — tests may not have run." >> $GITHUB_STEP_SUMMARY
+          fi
+
       - name: Cleanup
         if: always()
         run: |
           echo "Cleaning up processes..."
-          if [ -f backend/backend.pid ]; then
-            PID=$(cat backend/backend.pid)
-            echo "Killing backend process $PID"
-            kill $PID 2>/dev/null || true
-            # Wait for graceful shutdown
-            sleep 2
-            # Force kill if still running
-            kill -9 $PID 2>/dev/null || true
-          fi
-          if [ -f frontend/frontend.pid ]; then
-            PID=$(cat frontend/frontend.pid)
-            echo "Killing frontend process $PID"
-            kill $PID 2>/dev/null || true
-            sleep 2
-            kill -9 $PID 2>/dev/null || true
-          fi
-          # Kill any remaining node processes on ports 3000 and 5173
+          for pidfile in backend/backend.pid frontend/frontend.pid; do
+            if [ -f "$pidfile" ]; then
+              PID=$(cat "$pidfile")
+              echo "Stopping process $PID (from $pidfile)"
+              kill "$PID" 2>/dev/null || true
+              sleep 1
+              kill -0 "$PID" 2>/dev/null && kill -9 "$PID" 2>/dev/null || true
+            fi
+          done
+          # Kill any remaining node processes on our ports
           lsof -ti:3000 | xargs kill -9 2>/dev/null || true
           lsof -ti:5173 | xargs kill -9 2>/dev/null || true
           echo "Cleanup complete"
-

--- a/backend/src/utils/secrets.ts
+++ b/backend/src/utils/secrets.ts
@@ -94,8 +94,9 @@ const ALLOWED_SECRET_PATTERNS = [
 /**
  * Allow environment variable fallback (disabled in production by default)
  */
-const ALLOW_ENV_FALLBACK = process.env.ALLOW_SECRET_ENV_FALLBACK === 'true' || 
-                           process.env.NODE_ENV === 'development';
+const ALLOW_ENV_FALLBACK = process.env.ALLOW_SECRET_ENV_FALLBACK === 'true' ||
+                           process.env.NODE_ENV === 'development' ||
+                           process.env.NODE_ENV === 'test';
 
 /**
  * Secret expiration settings

--- a/docs/E2E_TESTS_DISABLED.md
+++ b/docs/E2E_TESTS_DISABLED.md
@@ -1,24 +1,38 @@
-# E2E Tests Temporarily Disabled - Investigation Required
+# E2E Tests - CI/CD Status
 
-**Date:** April 25, 2026  
-**Status:** 🔴 Disabled  
+**Date:** April 25, 2026 (updated June 24, 2026)  
+**Status:** Re-enabled (Issue #142)  
 **GitHub Actions Workflow:** `.github/workflows/e2e-tests.yml`  
-**Related Issue:** [Create GitHub issue to track this]
+**Related Issue:** #142
 
 ---
 
 ## Executive Summary
 
-GitHub Actions E2E tests have been temporarily disabled due to consistent failures in the CI/CD pipeline. While the test infrastructure is well-established (70-80% pass rate locally on Chromium), the tests are not stable enough for automated CI/CD execution. This document outlines the known issues, relevant logs, and the plan to resolve them before re-enabling automated testing.
+E2E tests are now re-enabled in GitHub Actions (PR for issue #142). The root cause of CI
+failures was identified: the backend's secrets utility (`secrets.ts`) only allowed env var
+fallback in `NODE_ENV=development`, but CI runs with `NODE_ENV=test`. This caused JWT
+token generation to fail with a 500 error on login, even though the health check passed.
+
+### Fixes Applied (June 2026)
+
+1. **Root cause fix:** `ALLOW_ENV_FALLBACK` in `secrets.ts` now includes `NODE_ENV=test`
+2. **Postgres version:** Bumped CI service from Postgres 15 to 16 (matches production)
+3. **Health check:** `pg_isready` now specifies `-U mealplanner` (was failing as `root`)
+4. **Login verification:** Workflow verifies the login endpoint works before running tests
+5. **Backend startup timeout:** Increased from 60s to 90s (45 attempts x 2s)
+6. **Global setup retries:** 3 retries with backoff in CI
+7. **Test summary:** Results posted to GitHub step summary
+8. **Cleanup robustness:** Graceful stop before SIGKILL, loop-based PID cleanup
 
 ---
 
 ## Current Status
 
-- ✅ **Local Testing:** 70-80% pass rate on Chromium (9-10 of 11 tests passing)
-- ❌ **CI/CD Testing:** Consistent failures in GitHub Actions
-- 🔴 **Workflow Status:** Disabled (manual trigger only via `workflow_dispatch`)
-- 📊 **Test Coverage:** 11 tests covering authentication and recipe browsing
+- **Local Testing:** 70-80% pass rate on Chromium (9-10 of 11 tests passing)
+- **CI/CD Testing:** Re-enabled with reliability fixes
+- **Workflow Status:** Active on push/PR to main
+- **Test Coverage:** 11 tests covering authentication and recipe browsing
 
 ---
 

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -11,10 +11,27 @@ async function globalSetup(config: FullConfig) {
   const backendURL = baseURL?.replace(':5173', ':3000') || 'http://localhost:3000';
 
   console.log('Global Setup: Verifying backend is reachable...');
-  await verifyBackendAuth(backendURL);
-  console.log('Global Setup: Backend verified');
+
+  const maxRetries = process.env.CI ? 3 : 1;
+  let lastError: Error | undefined;
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      await verifyBackendAuth(backendURL);
+      console.log('Global Setup: Backend verified');
+      return;
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      console.error(`Global Setup: Attempt ${attempt}/${maxRetries} failed: ${lastError.message}`);
+      if (attempt < maxRetries) {
+        const delay = attempt * 2000;
+        console.log(`Global Setup: Retrying in ${delay / 1000}s...`);
+        await new Promise(resolve => setTimeout(resolve, delay));
+      }
+    }
+  }
+
+  throw lastError;
 }
 
 export default globalSetup;
-
-// Made with Bob


### PR DESCRIPTION
## Summary
Fixes #142

- **Root cause:** `secrets.ts` only allowed env var fallback for `NODE_ENV=development`, but CI uses `NODE_ENV=test` — `JWT_SECRET` was unreachable, causing a 500 on login even though the health check passed
- **Postgres:** bumped service from 15→16 to match prod; fixed `pg_isready` health check that was connecting as `root` role
- **Reliability:** added login endpoint verification step, increased backend startup timeout (60s→90s), added retry logic with backoff in Playwright global setup, added test result summary to GitHub step output, improved cleanup with graceful stop before SIGKILL
- **Misc:** moved Playwright browser install before DB setup (parallelizable with cache), added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env, renamed artifact from "test-videos" to "test-traces"

## Test plan
- [ ] Verify the E2E workflow passes on this PR (check Actions tab)
- [ ] Confirm login verification step shows HTTP 200 in logs
- [ ] Confirm test summary appears in workflow step output
- [ ] On failure, verify server logs and traces are uploaded as artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)