### PR TITLE
feat(ftue): simplify family auth, stock visual passwords, unified onboarding

### DIFF
--- a/backend/prisma/migrations/20260624000000_ftue_stock_images_and_device_member/migration.sql
+++ b/backend/prisma/migrations/20260624000000_ftue_stock_images_and_device_member/migration.sql
@@ -1,0 +1,5 @@
+-- Add stock visual password image URL to family members (alternative to recipe-based visual password)
+ALTER TABLE "family_members" ADD COLUMN IF NOT EXISTS "visual_password_image_url" TEXT;
+
+-- Add family member tracking to device tokens (remember which member logged in)
+ALTER TABLE "device_tokens" ADD COLUMN IF NOT EXISTS "family_member_id" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -39,12 +39,14 @@ model User {
 }
 
 model DeviceToken {
-  id        String   @id @default(uuid())
-  userId    String   @map("user_id")
-  tokenHash String   @unique @map("token_hash")
-  expiresAt DateTime @map("expires_at")
-  createdAt DateTime @default(now()) @map("created_at")
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id             String        @id @default(uuid())
+  userId         String        @map("user_id")
+  familyMemberId String?       @map("family_member_id")
+  tokenHash      String        @unique @map("token_hash")
+  expiresAt      DateTime      @map("expires_at")
+  createdAt      DateTime      @default(now()) @map("created_at")
+  user           User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  familyMember   FamilyMember? @relation(fields: [familyMemberId], references: [id], onDelete: SetNull)
 
   @@index([userId])
   @@index([tokenHash])
@@ -78,9 +80,11 @@ model FamilyMember {
   dietaryRestrictions    Json           @map("dietary_restrictions")
   createdAt              DateTime       @default(now()) @map("created_at")
   visualPasswordRecipeId String?        @map("visual_password_recipe_id")
+  visualPasswordImageUrl String?        @map("visual_password_image_url")
   user                   User           @relation(fields: [userId], references: [id], onDelete: Cascade)
   plannedMeals           PlannedMeal[]
   recipeRatings          RecipeRating[]
+  deviceTokens           DeviceToken[]
 
   @@map("family_members")
 }

--- a/backend/src/controllers/visualAuth.controller.ts
+++ b/backend/src/controllers/visualAuth.controller.ts
@@ -20,6 +20,17 @@ const DEVICE_COOKIE_NAME = 'mealplanner_device';
 const DEVICE_TOKEN_DAYS = 14;
 const VISUAL_CHALLENGE_SIZE = 4; // 1 correct + 3 decoys
 
+const STOCK_IMAGES = [
+  { id: 'stock-burger', title: 'Burger', imageUrl: '/visual-login/burger.svg' },
+  { id: 'stock-pizza', title: 'Pizza', imageUrl: '/visual-login/pizza.svg' },
+  { id: 'stock-sushi', title: 'Sushi', imageUrl: '/visual-login/sushi.svg' },
+  { id: 'stock-salad', title: 'Salad', imageUrl: '/visual-login/salad.svg' },
+  { id: 'stock-pasta', title: 'Pasta', imageUrl: '/visual-login/pasta.svg' },
+  { id: 'stock-taco', title: 'Taco', imageUrl: '/visual-login/taco.svg' },
+  { id: 'stock-cake', title: 'Cake', imageUrl: '/visual-login/cake.svg' },
+  { id: 'stock-soup', title: 'Soup', imageUrl: '/visual-login/soup.svg' },
+];
+
 function hashToken(token: string): string {
   return crypto.createHash('sha256').update(token).digest('hex');
 }
@@ -92,18 +103,33 @@ export async function getVisualChallenge(req: Request, res: Response, next: Next
     const member = await withRetry(() =>
       prisma.familyMember.findUnique({
         where: { id: memberId },
-        select: { visualPasswordRecipeId: true },
+        select: { visualPasswordRecipeId: true, visualPasswordImageUrl: true },
       })
     );
 
     if (!member) {
       throw new AppError('Family member not found', 404);
     }
+
+    // Stock image visual password
+    if (member.visualPasswordImageUrl) {
+      const correct = STOCK_IMAGES.find((s) => s.imageUrl === member.visualPasswordImageUrl);
+      if (!correct) {
+        throw new AppError('Visual password image not found', 500);
+      }
+      const decoys = STOCK_IMAGES.filter((s) => s.imageUrl !== member.visualPasswordImageUrl);
+      shuffle(decoys);
+      const images = [correct, ...decoys.slice(0, VISUAL_CHALLENGE_SIZE - 1)];
+      shuffle(images);
+      res.json({ images });
+      return;
+    }
+
+    // Recipe-based visual password (legacy)
     if (!member.visualPasswordRecipeId) {
       throw new AppError('Visual password not set for this family member', 400);
     }
 
-    // Get the correct recipe
     const correctRecipe = await withRetry(() =>
       prisma.recipe.findUnique({
         where: { id: member.visualPasswordRecipeId! },
@@ -114,7 +140,6 @@ export async function getVisualChallenge(req: Request, res: Response, next: Next
       throw new AppError('Visual password recipe not found', 500);
     }
 
-    // Get random decoy recipes (with images, excluding the correct one)
     const decoys = await withRetry(() =>
       prisma.recipe.findMany({
         where: {
@@ -138,36 +163,44 @@ export async function getVisualChallenge(req: Request, res: Response, next: Next
 
 /**
  * POST /api/auth/login/visual
- * Body: { memberId, recipeId }
+ * Body: { memberId, imageId } where imageId is a recipe ID or stock image ID (e.g. "stock-burger")
  * Validates the family member's visual password and issues JWT + 14-day device cookie on success.
  */
 export async function visualLogin(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
-    const { memberId, recipeId } = req.body as { memberId: string; recipeId: string };
+    const { memberId, recipeId: imageId } = req.body as { memberId: string; recipeId: string };
 
-    if (!memberId || !recipeId) {
+    if (!memberId || !imageId) {
       throw new AppError('memberId and recipeId are required', 400);
     }
 
     const member = await withRetry(() =>
       prisma.familyMember.findUnique({
         where: { id: memberId },
-        select: { id: true, name: true, userId: true, visualPasswordRecipeId: true },
+        select: { id: true, name: true, userId: true, visualPasswordRecipeId: true, visualPasswordImageUrl: true },
       })
     );
 
     if (!member) {
       throw new AppError('Invalid credentials', 401);
     }
-    if (!member.visualPasswordRecipeId) {
+
+    // Check stock image password
+    if (member.visualPasswordImageUrl) {
+      const stockMatch = STOCK_IMAGES.find((s) => s.id === imageId);
+      if (!stockMatch || stockMatch.imageUrl !== member.visualPasswordImageUrl) {
+        logger.warn('Visual password mismatch (stock)', { memberId });
+        throw new AppError('Invalid credentials', 401);
+      }
+    } else if (member.visualPasswordRecipeId) {
+      if (member.visualPasswordRecipeId !== imageId) {
+        logger.warn('Visual password mismatch (recipe)', { memberId });
+        throw new AppError('Invalid credentials', 401);
+      }
+    } else {
       throw new AppError('Visual password not configured', 400);
     }
-    if (member.visualPasswordRecipeId !== recipeId) {
-      logger.warn('Visual password mismatch', { memberId });
-      throw new AppError('Invalid credentials', 401);
-    }
 
-    // Issue JWT for the parent user account
     const user = await withRetry(() =>
       prisma.user.findUnique({
         where: { id: member.userId },
@@ -186,10 +219,9 @@ export async function visualLogin(req: Request, res: Response, next: NextFunctio
       role: user.role,
     });
 
-    // Create auth session for refresh token
     const refreshTokenHash = hashSessionToken(tokens.refreshToken);
     const sessionExpiresAt = new Date();
-    sessionExpiresAt.setDate(sessionExpiresAt.getDate() + 1); // 24 hours
+    sessionExpiresAt.setDate(sessionExpiresAt.getDate() + 1);
 
     await withRetry(() =>
       prisma.authSession.create({
@@ -203,10 +235,8 @@ export async function visualLogin(req: Request, res: Response, next: NextFunctio
       })
     );
 
-    // Set auth cookies
     setAuthCookies(res, tokens.accessToken, tokens.refreshToken);
 
-    // Issue 14-day device token
     const rawToken = generateDeviceToken();
     const tokenHash = hashToken(rawToken);
     const deviceExpiresAt = new Date();
@@ -214,7 +244,7 @@ export async function visualLogin(req: Request, res: Response, next: NextFunctio
 
     await withRetry(() =>
       prisma.deviceToken.create({
-        data: { userId: user.id, tokenHash, expiresAt: deviceExpiresAt },
+        data: { userId: user.id, familyMemberId: member.id, tokenHash, expiresAt: deviceExpiresAt },
       })
     );
 
@@ -225,6 +255,8 @@ export async function visualLogin(req: Request, res: Response, next: NextFunctio
     res.json({
       message: 'Visual login successful',
       user: { id: user.id, email: user.email, name: member.name, role: user.role },
+      familyMemberId: member.id,
+      memberName: member.name,
     });
   } catch (err) {
     next(err);
@@ -250,6 +282,9 @@ export async function deviceLogin(req: Request, res: Response, next: NextFunctio
         include: {
           user: {
             select: { id: true, email: true, familyName: true, role: true, isBlocked: true },
+          },
+          familyMember: {
+            select: { id: true, name: true },
           },
         },
       })
@@ -312,14 +347,18 @@ export async function deviceLogin(req: Request, res: Response, next: NextFunctio
 
     setDeviceCookie(res, newRawToken);
 
+    const memberName = deviceToken.familyMember?.name ?? deviceToken.user.familyName;
+
     res.json({
       message: 'Device login successful',
       user: {
         id: deviceToken.user.id,
         email: deviceToken.user.email,
-        name: deviceToken.user.familyName,
+        name: memberName,
         role: deviceToken.user.role,
       },
+      familyMemberId: deviceToken.familyMember?.id ?? null,
+      memberName: deviceToken.familyMember?.name ?? null,
     });
   } catch (err) {
     next(err);
@@ -388,15 +427,15 @@ export async function getVisualPasswordStatus(req: Request, res: Response, next:
       const member = await withRetry(() =>
         prisma.familyMember.findFirst({
           where: { id: familyMemberId, userId },
-          select: { visualPasswordRecipeId: true },
+          select: { visualPasswordRecipeId: true, visualPasswordImageUrl: true },
         })
       );
-      res.json({ hasVisualPassword: !!member?.visualPasswordRecipeId });
+      res.json({ hasVisualPassword: !!(member?.visualPasswordRecipeId || member?.visualPasswordImageUrl) });
     } else {
       const members = await withRetry(() =>
         prisma.familyMember.findMany({
           where: { userId },
-          select: { id: true, name: true, visualPasswordRecipeId: true },
+          select: { id: true, name: true, visualPasswordRecipeId: true, visualPasswordImageUrl: true },
           orderBy: { name: 'asc' },
         })
       );
@@ -404,7 +443,7 @@ export async function getVisualPasswordStatus(req: Request, res: Response, next:
         members: members.map((m) => ({
           id: m.id,
           name: m.name,
-          hasVisualPassword: !!m.visualPasswordRecipeId,
+          hasVisualPassword: !!(m.visualPasswordRecipeId || m.visualPasswordImageUrl),
         })),
       });
     }
@@ -458,4 +497,54 @@ export async function getVisualSetupImages(_req: Request, res: Response, next: N
   }
 }
 
-// Made with Bob
+/**
+ * GET /api/auth/visual-setup/stock-images
+ * Returns the list of bundled stock food images available for visual password setup.
+ * No auth required — used during the Setup wizard.
+ */
+export function getStockImages(_req: Request, res: Response): void {
+  res.json({ images: STOCK_IMAGES });
+}
+
+/**
+ * POST /api/auth/visual-password/setup-stock
+ * Body: { familyMemberId, imageUrl }
+ * Sets a family member's visual password to a stock image.
+ * Requires authentication. The family member must belong to the authenticated user.
+ */
+export async function setupStockVisualPassword(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const userId = (req as any).user?.userId;
+    const { familyMemberId, imageUrl } = req.body as { familyMemberId: string; imageUrl: string };
+
+    if (!familyMemberId || !imageUrl) {
+      throw new AppError('familyMemberId and imageUrl are required', 400);
+    }
+
+    const stockImage = STOCK_IMAGES.find((s) => s.imageUrl === imageUrl);
+    if (!stockImage) {
+      throw new AppError('Invalid stock image', 400);
+    }
+
+    const member = await withRetry(() =>
+      prisma.familyMember.findFirst({
+        where: { id: familyMemberId, userId },
+      })
+    );
+    if (!member) {
+      throw new AppError('Family member not found', 404);
+    }
+
+    await withRetry(() =>
+      prisma.familyMember.update({
+        where: { id: familyMemberId },
+        data: { visualPasswordImageUrl: imageUrl, visualPasswordRecipeId: null },
+      })
+    );
+
+    logger.info('Stock visual password set', { familyMemberId, userId });
+    res.json({ message: 'Visual password set', image: stockImage });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/routes/visualAuth.routes.ts
+++ b/backend/src/routes/visualAuth.routes.ts
@@ -11,9 +11,11 @@ import {
   visualLogin,
   deviceLogin,
   setupVisualPassword,
+  setupStockVisualPassword,
   getVisualPasswordStatus,
   deviceLogout,
   getVisualSetupImages,
+  getStockImages,
 } from '../controllers/visualAuth.controller';
 
 const router: Router = Router();
@@ -24,10 +26,12 @@ router.get('/visual-challenge/:userId', getVisualChallenge);
 router.post('/login/visual', visualLogin);
 router.post('/login/device', deviceLogin);
 router.post('/logout/device', deviceLogout);
+router.get('/visual-setup/stock-images', getStockImages);
 
 // ── Authenticated endpoints ───────────────────────────────────────────────
 router.get('/visual-password/status', authenticate, getVisualPasswordStatus);
 router.post('/visual-password/setup', authenticate, setupVisualPassword);
+router.post('/visual-password/setup-stock', authenticate, setupStockVisualPassword);
 router.get('/visual-setup/images', authenticate, getVisualSetupImages);
 
 export default router;

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -7,6 +7,13 @@ import { FullConfig } from '@playwright/test';
 import { verifyBackendAuth } from './helpers/api-auth';
 
 async function globalSetup(config: FullConfig) {
+  const activeProjects = config.projects.filter((p) => !p.grep || !p.grepInvert);
+  const onlyFtue = activeProjects.length === 1 && activeProjects[0].name === 'ftue-audit';
+  if (onlyFtue || process.env.SKIP_GLOBAL_SETUP === '1') {
+    console.log('Global Setup: Skipped (FTUE audit handles its own auth)');
+    return;
+  }
+
   const { baseURL } = config.projects[0].use;
   const backendURL = baseURL?.replace(':5173', ':3000') || 'http://localhost:3000';
 

--- a/frontend/e2e/tests/ftue/ftue-audit.spec.ts
+++ b/frontend/e2e/tests/ftue/ftue-audit.spec.ts
@@ -1,0 +1,721 @@
+import { test, expect, Page } from '@playwright/test';
+
+// ── Config ──────────────────────────────────────────────────────────────────
+// Run against the Pi:
+//   BASE_URL=http://192.168.4.110 FTUE_EMAIL=you@example.com FTUE_PASSWORD=... npx playwright test e2e/tests/ftue/
+// Run against local dev (defaults):
+//   npx playwright test e2e/tests/ftue/
+
+const EMAIL = process.env.FTUE_EMAIL || 'test@example.com';
+const PASSWORD = process.env.FTUE_PASSWORD || 'TestPass123!';
+const CONFIGURED_BASE_URL = process.env.BASE_URL || 'http://localhost:5173';
+
+function screenshotPath(name: string) {
+  return `test-results/ftue-screenshots/${name}.png`;
+}
+
+async function screenshot(page: Page, name: string) {
+  await page.screenshot({ path: screenshotPath(name), fullPage: true });
+}
+
+function getBackendURL(): string {
+  const base = CONFIGURED_BASE_URL;
+  if (base.includes(':5173')) return base.replace(':5173', ':3000');
+  // Pi: backend is behind the same nginx on the same origin
+  return base;
+}
+
+async function loginViaAPI(page: Page): Promise<boolean> {
+  const backendURL = getBackendURL();
+  try {
+    const resp = await page.request.post(`${backendURL}/api/auth/login`, {
+      data: { email: EMAIL, password: PASSWORD },
+    });
+    return resp.ok();
+  } catch {
+    return false;
+  }
+}
+
+// ── 1. Visual Login Screen (LocalLogin) ─────────────────────────────────────
+
+test.describe('Visual Login Screen (/login)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('screenshots the login screen', async ({ page }) => {
+    await screenshot(page, '01-login-screen');
+  });
+
+  test('#235 — branding should be consistent, not "Family Kitchen" vs "Family Meal Planner"', async ({ page }) => {
+    const heading = page.locator('h4, h3, h2').first();
+    const text = await heading.textContent();
+    // Document what the heading actually says
+    console.log(`Login heading text: "${text}"`);
+    // The welcome page says "Family Meal Planner" — flag if login says something different
+    if (text && !text.includes('Meal Planner')) {
+      console.warn(`ISSUE #235: Login heading says "${text}" instead of "Family Meal Planner"`);
+    }
+    await screenshot(page, '01a-login-heading');
+  });
+
+  test('#242 — "Classic sign-in" link should have adequate contrast', async ({ page }) => {
+    const classicLink = page.getByText(/classic sign-in/i);
+    if (await classicLink.isVisible()) {
+      const color = await classicLink.evaluate((el) => {
+        const style = window.getComputedStyle(el);
+        return { color: style.color, background: style.backgroundColor };
+      });
+      console.log(`Classic sign-in link — color: ${color.color}, bg: ${color.background}`);
+      // Grey text on white background is the known issue
+      await classicLink.scrollIntoViewIfNeeded();
+      await screenshot(page, '01b-classic-signin-link');
+    }
+  });
+
+  test('user cards are displayed for family members', async ({ page }) => {
+    const userCards = page.getByRole('button').filter({ hasText: /\w+/ });
+    const count = await userCards.count();
+    console.log(`Found ${count} user cards on login screen`);
+    expect(count).toBeGreaterThan(0);
+    await screenshot(page, '01c-user-cards');
+  });
+
+  test('stepper is visible and shows correct steps', async ({ page }) => {
+    const stepper = page.locator('.MuiStepper-root');
+    if (await stepper.isVisible()) {
+      const stepLabels = await stepper.locator('.MuiStepLabel-label').allTextContents();
+      console.log(`Login stepper labels: ${JSON.stringify(stepLabels)}`);
+      await screenshot(page, '01d-login-stepper');
+    }
+  });
+});
+
+// ── 2. Welcome Screen (fresh install guard) ─────────────────────────────────
+
+test.describe('Welcome Screen (/welcome)', () => {
+  test('redirects to /login when users already exist', async ({ page }) => {
+    await page.goto('/welcome');
+    await page.waitForLoadState('networkidle');
+    // On an existing install, should redirect to /login
+    const url = page.url();
+    if (url.includes('/login')) {
+      console.log('Correctly redirected to /login (users exist)');
+    } else if (url.includes('/welcome')) {
+      // Fresh install — screenshot the welcome page
+      await screenshot(page, '02-welcome-fresh-install');
+
+      // #232 — Test disabled submit button with no explanation
+      const passwordInput = page.getByLabel(/^password$/i);
+      const submitBtn = page.getByRole('button', { name: /create admin account/i });
+
+      if (await passwordInput.isVisible()) {
+        await page.getByLabel(/family name/i).fill('Tracy Test');
+        await page.getByLabel(/email/i).fill('tracy@test.com');
+        await passwordInput.fill('weak');
+        await page.getByLabel(/confirm password/i).fill('weak');
+
+        // Button should be disabled — but is there ANY visible explanation?
+        const isDisabled = await submitBtn.isDisabled();
+        const strengthBar = page.locator('.MuiLinearProgress-root');
+        const strengthVisible = await strengthBar.isVisible();
+        // Look for any "too weak" messaging near the button
+        const tooWeakMsg = page.getByText(/too weak|not strong enough|stronger password/i);
+        const hasTooWeakMsg = await tooWeakMsg.isVisible().catch(() => false);
+
+        console.log(`ISSUE #232 check — button disabled: ${isDisabled}, strength bar visible: ${strengthVisible}, has explanation: ${hasTooWeakMsg}`);
+        if (isDisabled && !hasTooWeakMsg) {
+          console.warn('ISSUE #232 CONFIRMED: Submit button is disabled with no visible explanation');
+        }
+        await screenshot(page, '02a-welcome-weak-password');
+
+        // #245 — Password strength scoring is opaque
+        await passwordInput.fill('Abcdefgh'); // mixed case, 8 chars = 50%
+        const strengthLabel = page.getByText(/weak|medium|strong/i);
+        if (await strengthLabel.isVisible()) {
+          const label = await strengthLabel.textContent();
+          const btnDisabledNow = await submitBtn.isDisabled();
+          console.log(`ISSUE #245 check — "Abcdefgh" shows: "${label}", button disabled: ${btnDisabledNow}`);
+        }
+        await screenshot(page, '02b-welcome-medium-password');
+      }
+    }
+  });
+});
+
+// ── 3. Classic Login (/login/classic) ───────────────────────────────────────
+
+test.describe('Classic Login (/login/classic)', () => {
+  test('screenshots classic login page', async ({ page }) => {
+    await page.goto('/login/classic');
+    await page.waitForLoadState('networkidle');
+    await screenshot(page, '03-classic-login');
+  });
+});
+
+// ── 4. Setup Wizard (/setup) — requires auth ───────────────────────────────
+
+test.describe('Setup Wizard (/setup)', () => {
+  test('screenshots setup wizard if accessible', async ({ page }) => {
+    // Authenticate first
+    if (!await loginViaAPI(page)) {
+      console.log('Cannot authenticate — skipping');
+      test.skip();
+      return;
+    }
+
+    await page.goto('/setup');
+    await page.waitForLoadState('networkidle');
+    const url = page.url();
+
+    if (url.includes('/setup')) {
+      await screenshot(page, '04-setup-wizard-step0');
+
+      // #240 — No Back button
+      const getStartedBtn = page.getByRole('button', { name: /get started/i });
+      if (await getStartedBtn.isVisible()) {
+        await getStartedBtn.click();
+        await page.waitForTimeout(500);
+        await screenshot(page, '04a-setup-step1-family');
+
+        const backBtn = page.getByRole('button', { name: /back/i });
+        const hasBackBtn = await backBtn.isVisible().catch(() => false);
+        console.log(`ISSUE #240 check — Back button visible on Step 1: ${hasBackBtn}`);
+        if (!hasBackBtn) {
+          console.warn('ISSUE #240 CONFIRMED: No Back button on Setup wizard Step 1');
+        }
+
+        // #241 — Stepper label overflow check
+        const stepper = page.locator('.MuiStepper-root');
+        if (await stepper.isVisible()) {
+          const stepperBox = await stepper.boundingBox();
+          const containerBox = await page.locator('.MuiContainer-root').first().boundingBox();
+          if (stepperBox && containerBox && stepperBox.width > containerBox.width) {
+            console.warn('ISSUE #241 CONFIRMED: Stepper overflows container');
+          }
+          const labels = await stepper.locator('.MuiStepLabel-label').allTextContents();
+          console.log(`Setup stepper labels: ${JSON.stringify(labels)}`);
+        }
+      }
+    } else {
+      console.log(`Setup wizard redirected to ${url} (FTUE already completed)`);
+      await screenshot(page, '04-setup-redirected');
+    }
+  });
+});
+
+// ── 5. Dashboard — onboarding, empty states, nudges ────────────────────────
+
+test.describe('Dashboard (/dashboard)', () => {
+  test.beforeEach(async ({ page }) => {
+    if (!await loginViaAPI(page)) {
+      test.skip();
+      return;
+    }
+
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('screenshots dashboard and checks for onboarding wizard', async ({ page }) => {
+    await screenshot(page, '05-dashboard');
+
+    // Check if OnboardingWizard dialog appeared
+    const dialog = page.locator('.MuiDialog-root');
+    const dialogVisible = await dialog.isVisible().catch(() => false);
+    if (dialogVisible) {
+      await screenshot(page, '05a-onboarding-wizard');
+
+      // #236 — Document redundant welcome screen
+      const wizardWelcome = dialog.getByText(/welcome to meal planner/i);
+      if (await wizardWelcome.isVisible().catch(() => false)) {
+        console.log('ISSUE #236: OnboardingWizard shows its own "Welcome" screen (redundant with Setup wizard Welcome)');
+      }
+
+      // Walk through all steps and screenshot
+      const nextBtn = dialog.getByRole('button', { name: /next/i });
+      for (let step = 1; step <= 3; step++) {
+        if (await nextBtn.isVisible().catch(() => false)) {
+          await nextBtn.click();
+          await page.waitForTimeout(500);
+          await screenshot(page, `05b-onboarding-step${step}`);
+        }
+      }
+
+      // #237 — Skip and check what gets persisted
+      const skipBtn = dialog.getByRole('button', { name: /skip/i });
+      if (await skipBtn.isVisible().catch(() => false)) {
+        await skipBtn.click();
+        await page.waitForTimeout(500);
+      } else {
+        // Close via X button
+        const closeBtn = dialog.getByLabel(/skip onboarding/i);
+        if (await closeBtn.isVisible().catch(() => false)) {
+          await closeBtn.click();
+          await page.waitForTimeout(500);
+        }
+      }
+    }
+  });
+
+  test('#244 — empty meal slot buttons should have adequate touch targets', async ({ page }) => {
+    // Close onboarding wizard if present
+    const dialog = page.locator('.MuiDialog-root');
+    if (await dialog.isVisible().catch(() => false)) {
+      const closeBtn = dialog.getByLabel(/skip onboarding/i);
+      if (await closeBtn.isVisible().catch(() => false)) {
+        await closeBtn.click();
+        await page.waitForTimeout(300);
+      }
+    }
+
+    const notPlannedBtns = page.getByRole('button', { name: /not planned/i });
+    const count = await notPlannedBtns.count();
+    if (count > 0) {
+      for (let i = 0; i < count; i++) {
+        const btn = notPlannedBtns.nth(i);
+        const box = await btn.boundingBox();
+        if (box) {
+          const tooSmall = box.height < 44 || box.width < 44;
+          if (tooSmall) {
+            console.warn(`ISSUE #244 CONFIRMED: "Not planned" button ${i} is ${Math.round(box.width)}x${Math.round(box.height)}px (minimum 44x44)`);
+          }
+        }
+      }
+      await screenshot(page, '05c-empty-meal-slots');
+    } else {
+      console.log('No empty meal slots visible (meals are planned)');
+    }
+  });
+
+  test('#238 — profile nudge should appear after skipping onboarding', async ({ page }) => {
+    // Clear relevant localStorage to simulate fresh state
+    await page.evaluate(() => {
+      localStorage.removeItem('profileNudgeDismissed');
+    });
+
+    // Check if onboarding was skipped (onboardingCompleted=true but no onboardingData)
+    const state = await page.evaluate(() => ({
+      completed: localStorage.getItem('onboardingCompleted'),
+      data: localStorage.getItem('onboardingData'),
+    }));
+    console.log(`Onboarding state — completed: ${state.completed}, has data: ${!!state.data}`);
+
+    if (state.completed && !state.data) {
+      // Reload to trigger nudge logic
+      await page.reload();
+      await page.waitForLoadState('networkidle');
+      const nudge = page.getByText(/complete your profile/i);
+      const nudgeVisible = await nudge.isVisible().catch(() => false);
+      console.log(`ISSUE #238 check — profile nudge visible after skip: ${nudgeVisible}`);
+      if (!nudgeVisible) {
+        console.warn('ISSUE #238 CONFIRMED: Profile nudge does not appear when onboarding was skipped');
+      }
+    }
+  });
+
+  test('quick action cards are visible and clickable', async ({ page }) => {
+    // Close onboarding wizard if present
+    const dialog = page.locator('.MuiDialog-root');
+    if (await dialog.isVisible().catch(() => false)) {
+      const closeBtn = dialog.getByLabel(/skip onboarding/i);
+      if (await closeBtn.isVisible().catch(() => false)) {
+        await closeBtn.click();
+        await page.waitForTimeout(300);
+      }
+    }
+
+    const actionCards = page.getByRole('button', {
+      name: /browse recipes|plan this week|view list|check pantry/i,
+    });
+    const count = await actionCards.count();
+    console.log(`Quick action cards visible: ${count}`);
+    expect(count).toBe(4);
+    await screenshot(page, '05d-quick-actions');
+  });
+});
+
+// ── 6. Member Welcome Tour (/member-welcome) ───────────────────────────────
+
+test.describe('Member Welcome Tour (/member-welcome)', () => {
+  test.beforeEach(async ({ page }) => {
+    if (!await loginViaAPI(page)) {
+      test.skip();
+      return;
+    }
+  });
+
+  test('screenshots all tour slides and checks UX', async ({ page }) => {
+    // Clear the FTUE flag so the tour is accessible
+    await page.goto('/member-welcome');
+    await page.waitForLoadState('networkidle');
+
+    if (!page.url().includes('/member-welcome')) {
+      console.log(`Member welcome redirected to ${page.url()}`);
+      test.skip();
+      return;
+    }
+
+    // Slide 0
+    await screenshot(page, '06-member-welcome-slide0');
+    const heading0 = await page.locator('h4').first().textContent();
+    console.log(`Slide 0 heading: "${heading0}"`);
+
+    // #246 — Check for swipe support
+    const hasTouchHandler = await page.evaluate(() => {
+      const root = document.querySelector('[class*="MuiBox-root"]');
+      if (!root) return false;
+      const events = (root as HTMLElement).ontouchstart;
+      return events !== undefined;
+    });
+    console.log(`ISSUE #246 check — touch handler on root: ${hasTouchHandler}`);
+    if (!hasTouchHandler) {
+      console.warn('ISSUE #246 CONFIRMED: No swipe/touch gesture support on member welcome tour');
+    }
+
+    // Navigate through all slides
+    const nextBtn = page.getByRole('button', { name: /next|let's go/i });
+    for (let slide = 1; slide <= 3; slide++) {
+      if (await nextBtn.isVisible().catch(() => false)) {
+        await nextBtn.click();
+        await page.waitForTimeout(400);
+        await screenshot(page, `06a-member-welcome-slide${slide}`);
+      }
+    }
+
+    // Check skip button visibility
+    const skipBtn = page.getByRole('button', { name: /skip/i });
+    // Skip is only visible on non-final slides, go back to check
+    await page.goto('/member-welcome');
+    await page.waitForLoadState('networkidle');
+    if (page.url().includes('/member-welcome')) {
+      const skipVisible = await skipBtn.isVisible().catch(() => false);
+      console.log(`Skip button visible on slide 0: ${skipVisible}`);
+    }
+  });
+
+  test('#239 — member FTUE flag should be per-member, not global', async ({ page }) => {
+    await page.goto('/member-welcome');
+    await page.waitForLoadState('networkidle');
+
+    if (!page.url().includes('/member-welcome')) {
+      test.skip();
+      return;
+    }
+
+    // Check the localStorage key
+    const key = await page.evaluate(() => {
+      const keys = Object.keys(localStorage).filter((k) => k.includes('ftue'));
+      return keys;
+    });
+    console.log(`FTUE-related localStorage keys: ${JSON.stringify(key)}`);
+
+    // Complete the tour
+    const nextBtn = page.getByRole('button', { name: /next/i });
+    for (let i = 0; i < 3; i++) {
+      if (await nextBtn.isVisible().catch(() => false)) {
+        await nextBtn.click();
+        await page.waitForTimeout(300);
+      }
+    }
+    const letsGoBtn = page.getByRole('button', { name: /let's go/i });
+    if (await letsGoBtn.isVisible().catch(() => false)) {
+      await letsGoBtn.click();
+      await page.waitForTimeout(300);
+    }
+
+    // Check the key that was set — is it per-member or global?
+    const postKey = await page.evaluate(() => {
+      return {
+        globalKey: localStorage.getItem('mealplanner_member_ftue_done'),
+        allKeys: Object.keys(localStorage).filter((k) => k.includes('ftue')),
+      };
+    });
+    console.log(`After tour — global key: ${postKey.globalKey}, all ftue keys: ${JSON.stringify(postKey.allKeys)}`);
+    if (postKey.globalKey && !postKey.allKeys.some((k: string) => k.includes('_done_'))) {
+      console.warn('ISSUE #239 CONFIRMED: FTUE done flag is a single global key, not per-member');
+    }
+  });
+});
+
+// ── 7. Recipes empty state ─────────────────────────────────────────────────
+
+test.describe('Recipe Discovery Empty State', () => {
+  test('#247 — empty state should explain missing Spoonacular key', async ({ page }) => {
+    if (!await loginViaAPI(page)) {
+      test.skip();
+      return;
+    }
+
+    await page.goto('/recipes');
+    await page.waitForLoadState('networkidle');
+    await screenshot(page, '07-recipes-page');
+
+    // Check if we're seeing the empty state
+    const emptyState = page.getByText(/welcome to your recipe collection/i);
+    if (await emptyState.isVisible().catch(() => false)) {
+      await screenshot(page, '07a-recipes-empty-state');
+
+      // Check for "no recipes available" without explanation
+      const noRecipesMsg = page.getByText(/no .* recipes available/i);
+      const noRecipesMsgVisible = await noRecipesMsg.isVisible().catch(() => false);
+      const apiKeyExplanation = page.getByText(/spoonacular|api key|connect/i);
+      const hasExplanation = await apiKeyExplanation.isVisible().catch(() => false);
+
+      if (noRecipesMsgVisible && !hasExplanation) {
+        console.warn('ISSUE #247 CONFIRMED: "No recipes available" shown with no explanation about missing API key');
+      }
+    } else {
+      console.log('Recipes page has content (not empty state)');
+    }
+  });
+});
+
+// ── 8. Mobile viewport validation ──────────────────────────────────────────
+
+test.describe('Mobile viewport checks', () => {
+  test.use({ viewport: { width: 375, height: 812 } }); // iPhone X
+
+  test('login screen renders correctly on mobile', async ({ page }) => {
+    await page.goto('/login');
+    await page.waitForLoadState('networkidle');
+    await screenshot(page, '08-mobile-login');
+
+    // Check if user cards stack properly
+    const cards = page.locator('.MuiCard-root');
+    const count = await cards.count();
+    if (count > 1) {
+      const first = await cards.first().boundingBox();
+      const second = await cards.nth(1).boundingBox();
+      if (first && second) {
+        const overlaps = first.x + first.width > second.x && first.y === second.y;
+        if (overlaps) {
+          console.warn('Mobile: User cards overlap horizontally');
+        }
+      }
+    }
+  });
+
+  test('#241 — setup stepper should not overflow on mobile', async ({ page }) => {
+    if (!await loginViaAPI(page)) {
+      test.skip();
+      return;
+    }
+
+    await page.goto('/setup');
+    await page.waitForLoadState('networkidle');
+
+    if (page.url().includes('/setup')) {
+      const stepper = page.locator('.MuiStepper-root');
+      if (await stepper.isVisible()) {
+        const stepperBox = await stepper.boundingBox();
+        if (stepperBox && stepperBox.width > 375) {
+          console.warn(`ISSUE #241 CONFIRMED: Stepper width (${Math.round(stepperBox.width)}px) exceeds mobile viewport (375px)`);
+        }
+        await screenshot(page, '08a-mobile-setup-stepper');
+      }
+    }
+  });
+
+  test('dashboard renders correctly on mobile', async ({ page }) => {
+    if (!await loginViaAPI(page)) {
+      test.skip();
+      return;
+    }
+
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    // Close onboarding if present
+    const dialog = page.locator('.MuiDialog-root');
+    if (await dialog.isVisible().catch(() => false)) {
+      const closeBtn = dialog.getByLabel(/skip onboarding/i);
+      if (await closeBtn.isVisible().catch(() => false)) {
+        await closeBtn.click();
+        await page.waitForTimeout(300);
+      }
+    }
+
+    await screenshot(page, '08b-mobile-dashboard');
+
+    // Check meal slot button sizes on mobile
+    const notPlannedBtns = page.getByRole('button', { name: /not planned/i });
+    const btnCount = await notPlannedBtns.count();
+    for (let i = 0; i < btnCount; i++) {
+      const box = await notPlannedBtns.nth(i).boundingBox();
+      if (box && (box.height < 44 || box.width < 44)) {
+        console.warn(`ISSUE #244 CONFIRMED (mobile): "Not planned" button ${i} is ${Math.round(box.width)}x${Math.round(box.height)}px`);
+      }
+    }
+  });
+
+  test('member welcome tour renders correctly on mobile', async ({ page }) => {
+    if (!await loginViaAPI(page)) {
+      test.skip();
+      return;
+    }
+
+    await page.goto('/member-welcome');
+    await page.waitForLoadState('networkidle');
+
+    if (page.url().includes('/member-welcome')) {
+      await screenshot(page, '08c-mobile-member-welcome');
+
+      // Check navigation button sizes
+      const nextBtn = page.getByRole('button', { name: /next/i });
+      if (await nextBtn.isVisible()) {
+        const box = await nextBtn.boundingBox();
+        if (box && box.height < 44) {
+          console.warn(`Mobile: Next button height (${Math.round(box.height)}px) below 44px touch target`);
+        }
+      }
+    }
+  });
+});
+
+// ── 9. Visual login flow for Tracy ─────────────────────────────────────────
+
+test.describe('Visual login flow — Tracy', () => {
+  test('Tracy can be selected on the login screen', async ({ page }) => {
+    await page.goto('/login');
+    await page.waitForLoadState('networkidle');
+
+    const tracyCard = page.getByText('Tracy');
+    const tracyVisible = await tracyCard.isVisible().catch(() => false);
+    console.log(`Tracy visible on login screen: ${tracyVisible}`);
+
+    if (tracyVisible) {
+      await screenshot(page, '09-login-tracy-visible');
+      await tracyCard.click();
+      await page.waitForTimeout(1000);
+      await screenshot(page, '09a-login-tracy-selected');
+
+      // Check what happens — visual challenge or setup mode?
+      const setupMode = page.getByText(/first-time setup/i);
+      const visualChallenge = page.getByText(/tap the image you chose/i);
+      const errorAlert = page.getByRole('alert');
+
+      if (await setupMode.isVisible().catch(() => false)) {
+        console.log('Tracy enters setup mode (no visual password set)');
+        await screenshot(page, '09b-tracy-setup-mode');
+
+        // #234 — If we sign in and no recipe images exist, we hit the dead end
+        console.log('ISSUE #234: If no recipe images exist after sign-in, Tracy will be bounced to dashboard');
+      } else if (await visualChallenge.isVisible().catch(() => false)) {
+        console.log('Tracy has a visual password — challenge displayed');
+        await screenshot(page, '09b-tracy-visual-challenge');
+
+        // Check that challenge images are actually loaded
+        const images = page.locator('.MuiCardMedia-root');
+        const imgCount = await images.count();
+        console.log(`Visual challenge images: ${imgCount}`);
+        for (let i = 0; i < imgCount; i++) {
+          const naturalWidth = await images.nth(i).evaluate(
+            (el) => (el as HTMLImageElement).naturalWidth
+          );
+          if (naturalWidth === 0) {
+            console.warn(`Visual challenge image ${i} failed to load`);
+          }
+        }
+      } else if (await errorAlert.isVisible().catch(() => false)) {
+        const errorText = await errorAlert.textContent();
+        console.warn(`Error after selecting Tracy: "${errorText}"`);
+        await screenshot(page, '09b-tracy-error');
+      }
+    } else {
+      console.log('Tracy not found on login screen');
+    }
+  });
+});
+
+// ── 10. Additional checks — things not in the original 15 ──────────────────
+
+test.describe('Additional FTUE checks', () => {
+  test('page title is set correctly', async ({ page }) => {
+    await page.goto('/login');
+    await page.waitForLoadState('networkidle');
+    const title = await page.title();
+    console.log(`Page title: "${title}"`);
+    // Should match the branding
+    expect(title).toBeTruthy();
+  });
+
+  test('favicon loads', async ({ page }) => {
+    await page.goto('/login');
+    const faviconResp = await page.request.get('/favicon.svg');
+    console.log(`Favicon status: ${faviconResp.status()}`);
+    expect(faviconResp.ok()).toBeTruthy();
+  });
+
+  test('no console errors on login page', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        errors.push(msg.text());
+      }
+    });
+
+    await page.goto('/login');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(2000);
+
+    if (errors.length > 0) {
+      console.warn(`Console errors on login page:\n${errors.join('\n')}`);
+    }
+    console.log(`Console errors found: ${errors.length}`);
+  });
+
+  test('no console errors on dashboard', async ({ page }) => {
+    if (!await loginViaAPI(page)) {
+      test.skip();
+      return;
+    }
+
+    const errors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        errors.push(msg.text());
+      }
+    });
+
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(2000);
+
+    // Close onboarding if present
+    const dialog = page.locator('.MuiDialog-root');
+    if (await dialog.isVisible().catch(() => false)) {
+      const closeBtn = dialog.getByLabel(/skip onboarding/i);
+      if (await closeBtn.isVisible().catch(() => false)) {
+        await closeBtn.click();
+        await page.waitForTimeout(300);
+      }
+    }
+
+    if (errors.length > 0) {
+      console.warn(`Console errors on dashboard:\n${errors.join('\n')}`);
+    }
+    console.log(`Console errors found: ${errors.length}`);
+  });
+
+  test('loading states do not flash — login screen loads in under 3s', async ({ page }) => {
+    const start = Date.now();
+    await page.goto('/login');
+    // Wait for actual user cards (not skeleton loaders)
+    try {
+      await page.locator('.MuiCard-root .MuiCardActionArea-root').first().waitFor({
+        state: 'visible',
+        timeout: 10000,
+      });
+    } catch {
+      console.warn('User cards did not appear within 10s');
+    }
+    const elapsed = Date.now() - start;
+    console.log(`Login screen loaded in ${elapsed}ms`);
+    if (elapsed > 3000) {
+      console.warn(`Slow load: login screen took ${elapsed}ms (target: <3000ms)`);
+    }
+  });
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -67,6 +67,19 @@ export default defineConfig({
         ...devices['Desktop Chrome'],
       },
     },
+
+    // FTUE design audit — screenshots every onboarding screen, validates known issues
+    // Run: BASE_URL=http://192.168.4.110 FTUE_EMAIL=... FTUE_PASSWORD=... npx playwright test --project=ftue-audit
+    // Skips globalSetup since FTUE tests handle their own auth and test pre-auth flows.
+    {
+      name: 'ftue-audit',
+      testMatch: /.*\/ftue\/.*\.spec\.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+        screenshot: 'on',
+        trace: 'on',
+      },
+    },
   ],
 });
 

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Meal Planner",
+  "name": "Family Meal Planner",
   "short_name": "MealPlanner",
   "description": "Family meal planning and recipe management application",
   "start_url": "/",

--- a/frontend/public/visual-login/burger.svg
+++ b/frontend/public/visual-login/burger.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" rx="32" fill="#E74C3C"/>
+  <!-- Top bun -->
+  <path d="M50 95 Q50 55 100 55 Q150 55 150 95 Z" fill="#F5D6A8"/>
+  <!-- Sesame seeds -->
+  <ellipse cx="85" cy="72" rx="4" ry="3" fill="#FFF8E7" transform="rotate(-15 85 72)"/>
+  <ellipse cx="110" cy="65" rx="4" ry="3" fill="#FFF8E7" transform="rotate(10 110 65)"/>
+  <ellipse cx="125" cy="80" rx="4" ry="3" fill="#FFF8E7" transform="rotate(-5 125 80)"/>
+  <!-- Lettuce -->
+  <path d="M45 98 Q60 90 75 100 Q90 90 105 100 Q120 90 135 100 Q150 90 155 98 L155 105 Q140 95 125 105 Q110 95 95 105 Q80 95 65 105 Q50 95 45 105 Z" fill="#4CAF50"/>
+  <!-- Patty -->
+  <rect x="48" y="103" width="104" height="18" rx="4" fill="#6D4C3D"/>
+  <!-- Cheese -->
+  <path d="M46 103 L52 115 L148 115 L154 103 Z" fill="#FFC107"/>
+  <!-- Bottom bun -->
+  <rect x="50" y="121" width="100" height="24" rx="6" fill="#F5D6A8"/>
+</svg>

--- a/frontend/public/visual-login/cake.svg
+++ b/frontend/public/visual-login/cake.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" rx="32" fill="#E91E63"/>
+  <!-- Bottom cake layer -->
+  <rect x="45" y="110" width="110" height="40" rx="6" fill="#FFEAA7"/>
+  <!-- Top cake layer -->
+  <rect x="55" y="78" width="90" height="36" rx="5" fill="#FFEAA7"/>
+  <!-- Bottom frosting -->
+  <path d="M45 110 Q60 120 75 110 Q90 120 105 110 Q120 120 135 110 Q150 120 155 110 L155 116 L45 116 Z" fill="#FEFEFE"/>
+  <!-- Top frosting -->
+  <path d="M55 78 Q67 88 80 78 Q93 88 105 78 Q118 88 130 78 Q140 88 145 78 L145 84 L55 84 Z" fill="#FEFEFE"/>
+  <!-- Middle frosting line -->
+  <rect x="45" y="108" width="110" height="5" rx="2" fill="#F8BBD0"/>
+  <!-- Strawberry on top -->
+  <path d="M95 68 Q100 52 105 68 Q100 72 95 68 Z" fill="#EF5350"/>
+  <line x1="100" y1="52" x2="100" y2="48" stroke="#4CAF50" stroke-width="2"/>
+  <path d="M97 48 Q100 44 103 48" fill="none" stroke="#4CAF50" stroke-width="2" stroke-linecap="round"/>
+  <!-- Candles -->
+  <rect x="72" y="55" width="4" height="24" rx="2" fill="#FF7043"/>
+  <ellipse cx="74" cy="52" rx="3" ry="5" fill="#FFD54F"/>
+  <rect x="124" y="55" width="4" height="24" rx="2" fill="#42A5F5"/>
+  <ellipse cx="126" cy="52" rx="3" ry="5" fill="#FFD54F"/>
+  <!-- Plate -->
+  <ellipse cx="100" cy="152" rx="68" ry="8" fill="#FEFEFE" opacity="0.3"/>
+</svg>

--- a/frontend/public/visual-login/pasta.svg
+++ b/frontend/public/visual-login/pasta.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" rx="32" fill="#E67E22"/>
+  <!-- Plate -->
+  <ellipse cx="100" cy="120" rx="65" ry="35" fill="#FEFEFE"/>
+  <ellipse cx="100" cy="118" rx="58" ry="30" fill="#F5F5F5"/>
+  <!-- Sauce -->
+  <ellipse cx="100" cy="110" rx="40" ry="20" fill="#E74C3C" opacity="0.7"/>
+  <!-- Spaghetti noodles -->
+  <path d="M65 105 Q80 90 95 108 Q110 85 125 105" fill="none" stroke="#FFEAA7" stroke-width="4" stroke-linecap="round"/>
+  <path d="M60 115 Q78 95 98 115 Q118 92 140 112" fill="none" stroke="#FFEAA7" stroke-width="4" stroke-linecap="round"/>
+  <path d="M70 110 Q85 98 100 112 Q115 95 130 110" fill="none" stroke="#FFEAA7" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M62 120 Q82 102 102 118 Q122 100 138 118" fill="none" stroke="#FFEAA7" stroke-width="3" stroke-linecap="round"/>
+  <!-- Meatball -->
+  <circle cx="90" cy="105" r="10" fill="#8D6E63"/>
+  <circle cx="115" cy="108" r="9" fill="#8D6E63"/>
+  <!-- Basil leaf -->
+  <path d="M100 92 Q108 82 106 92 Q112 88 100 92" fill="#4CAF50"/>
+</svg>

--- a/frontend/public/visual-login/pizza.svg
+++ b/frontend/public/visual-login/pizza.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" rx="32" fill="#F39C12"/>
+  <!-- Pizza slice shape -->
+  <path d="M100 45 L155 150 Q100 165 45 150 Z" fill="#FFEAA7"/>
+  <!-- Crust -->
+  <path d="M45 150 Q100 165 155 150 Q100 175 45 150 Z" fill="#E2B96F"/>
+  <!-- Sauce showing through -->
+  <path d="M100 55 L148 145 Q100 158 52 145 Z" fill="#E74C3C" opacity="0.4"/>
+  <!-- Pepperoni -->
+  <circle cx="95" cy="95" r="10" fill="#C0392B"/>
+  <circle cx="115" cy="120" r="9" fill="#C0392B"/>
+  <circle cx="80" cy="125" r="8" fill="#C0392B"/>
+  <!-- Cheese spots -->
+  <ellipse cx="105" cy="75" rx="6" ry="4" fill="#FFF9E6" opacity="0.7"/>
+  <ellipse cx="88" cy="110" rx="5" ry="4" fill="#FFF9E6" opacity="0.7"/>
+  <ellipse cx="120" cy="140" rx="5" ry="3" fill="#FFF9E6" opacity="0.7"/>
+</svg>

--- a/frontend/public/visual-login/salad.svg
+++ b/frontend/public/visual-login/salad.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" rx="32" fill="#27AE60"/>
+  <!-- Bowl -->
+  <path d="M40 100 Q40 155 100 155 Q160 155 160 100 Z" fill="#FEFEFE"/>
+  <path d="M35 100 L165 100" stroke="#E0E0E0" stroke-width="3" stroke-linecap="round"/>
+  <!-- Lettuce leaves -->
+  <path d="M60 95 Q70 65 85 80 Q90 60 100 75 Q110 55 120 78 Q130 62 140 95" fill="#66BB6A"/>
+  <path d="M65 90 Q80 70 95 85 Q105 68 115 82 Q125 65 135 90" fill="#81C784"/>
+  <!-- Tomato slices -->
+  <circle cx="75" cy="95" r="10" fill="#EF5350"/>
+  <circle cx="125" cy="92" r="8" fill="#EF5350"/>
+  <!-- Cucumber slices -->
+  <circle cx="100" cy="88" r="9" fill="#A5D6A7"/>
+  <circle cx="100" cy="88" r="5" fill="#C8E6C9"/>
+  <!-- Crouton -->
+  <rect x="88" y="100" width="10" height="10" rx="2" fill="#FFCC80" transform="rotate(15 93 105)"/>
+  <rect x="112" y="98" width="9" height="9" rx="2" fill="#FFCC80" transform="rotate(-10 116 102)"/>
+  <!-- Egg slice -->
+  <ellipse cx="100" cy="105" rx="7" ry="5" fill="#FFF9C4"/>
+  <ellipse cx="100" cy="105" rx="3" ry="2" fill="#FFB74D"/>
+</svg>

--- a/frontend/public/visual-login/soup.svg
+++ b/frontend/public/visual-login/soup.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" rx="32" fill="#3498DB"/>
+  <!-- Bowl -->
+  <path d="M35 100 Q35 160 100 160 Q165 160 165 100 Z" fill="#FEFEFE"/>
+  <!-- Bowl rim -->
+  <ellipse cx="100" cy="100" rx="68" ry="12" fill="#F5F5F5"/>
+  <ellipse cx="100" cy="100" rx="65" ry="10" fill="#FEFEFE"/>
+  <!-- Soup liquid -->
+  <ellipse cx="100" cy="100" rx="58" ry="8" fill="#FF9800"/>
+  <!-- Soup surface details -->
+  <ellipse cx="85" cy="99" rx="12" ry="3" fill="#FFB74D" opacity="0.6"/>
+  <ellipse cx="118" cy="100" rx="10" ry="2.5" fill="#FFB74D" opacity="0.6"/>
+  <!-- Herb garnish -->
+  <path d="M95 96 Q100 88 105 96" fill="#4CAF50"/>
+  <path d="M90 98 Q95 92 100 98" fill="#66BB6A"/>
+  <!-- Crouton -->
+  <rect x="110" y="95" width="8" height="7" rx="1.5" fill="#FFCC80" transform="rotate(12 114 98)"/>
+  <!-- Steam -->
+  <path d="M80 80 Q78 70 82 60" fill="none" stroke="#FEFEFE" stroke-width="3" stroke-linecap="round" opacity="0.6"/>
+  <path d="M100 76 Q98 66 102 56" fill="none" stroke="#FEFEFE" stroke-width="3" stroke-linecap="round" opacity="0.6"/>
+  <path d="M120 80 Q118 70 122 60" fill="none" stroke="#FEFEFE" stroke-width="3" stroke-linecap="round" opacity="0.6"/>
+  <!-- Spoon handle -->
+  <path d="M140 90 Q155 85 160 70" fill="none" stroke="#BDBDBD" stroke-width="4" stroke-linecap="round"/>
+  <!-- Saucer/plate under bowl -->
+  <ellipse cx="100" cy="162" rx="72" ry="8" fill="#FEFEFE" opacity="0.3"/>
+</svg>

--- a/frontend/public/visual-login/sushi.svg
+++ b/frontend/public/visual-login/sushi.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" rx="32" fill="#2ECC71"/>
+  <!-- Sushi roll (maki) - outer nori wrap -->
+  <ellipse cx="100" cy="105" rx="50" ry="35" fill="#2C3E50"/>
+  <!-- Rice ring -->
+  <ellipse cx="100" cy="105" rx="42" ry="28" fill="#FEFEFE"/>
+  <!-- Salmon filling -->
+  <ellipse cx="100" cy="105" rx="22" ry="15" fill="#E8734A"/>
+  <!-- Avocado accent -->
+  <ellipse cx="92" cy="100" rx="6" ry="8" fill="#7CB342" opacity="0.8"/>
+  <!-- Chopsticks -->
+  <line x1="140" y1="50" x2="165" y2="155" stroke="#DEB887" stroke-width="4" stroke-linecap="round"/>
+  <line x1="150" y1="48" x2="170" y2="150" stroke="#DEB887" stroke-width="4" stroke-linecap="round"/>
+  <!-- Rice texture dots -->
+  <circle cx="85" cy="90" r="2" fill="#EEE" opacity="0.6"/>
+  <circle cx="115" cy="95" r="2" fill="#EEE" opacity="0.6"/>
+  <circle cx="100" cy="125" r="2" fill="#EEE" opacity="0.6"/>
+  <circle cx="78" cy="110" r="2" fill="#EEE" opacity="0.6"/>
+  <circle cx="122" cy="115" r="2" fill="#EEE" opacity="0.6"/>
+</svg>

--- a/frontend/public/visual-login/taco.svg
+++ b/frontend/public/visual-login/taco.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" rx="32" fill="#9B59B6"/>
+  <!-- Taco shell -->
+  <path d="M35 130 Q40 70 100 65 Q160 70 165 130 Z" fill="#F5D6A8"/>
+  <!-- Inner shell shadow -->
+  <path d="M42 125 Q47 78 100 73 Q153 78 158 125 Z" fill="#EDCA95"/>
+  <!-- Meat filling -->
+  <path d="M50 120 Q55 90 100 85 Q145 90 150 120 Z" fill="#A1887F"/>
+  <!-- Lettuce -->
+  <path d="M48 110 Q65 85 82 100 Q95 82 108 98 Q120 80 135 100 Q148 85 152 110" fill="#66BB6A"/>
+  <!-- Tomato chunks -->
+  <circle cx="75" cy="105" r="7" fill="#EF5350"/>
+  <circle cx="120" cy="100" r="6" fill="#EF5350"/>
+  <circle cx="100" cy="108" r="5" fill="#EF5350"/>
+  <!-- Cheese shreds -->
+  <path d="M70 95 L68 110" stroke="#FFC107" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M90 90 L88 108" stroke="#FFC107" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M110 92 L112 108" stroke="#FFC107" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M130 95 L132 110" stroke="#FFC107" stroke-width="2.5" stroke-linecap="round"/>
+  <!-- Sour cream dots -->
+  <circle cx="85" cy="98" r="3" fill="#FEFEFE" opacity="0.9"/>
+  <circle cx="108" cy="95" r="3.5" fill="#FEFEFE" opacity="0.9"/>
+</svg>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -35,6 +35,7 @@ import {
   ShoppingCart as ShoppingCartIcon,
   Kitchen as KitchenIcon,
   AccountCircle as AccountCircleIcon,
+  SwapHoriz as SwapHorizIcon,
   AdminPanelSettings as AdminIcon,
   LightMode as LightModeIcon,
   DarkMode as DarkModeIcon,
@@ -119,7 +120,7 @@ const Layout: React.FC = () => {
 
   // ── Family identity ──────────────────────────────────────────────────────
   const familyName = user?.name ?? 'Family';
-  const drawerTitle = `${familyName} Kitchen`;
+  const drawerTitle = `${familyName}'s Meal Planner`;
 
   const handleDrawerToggle = () => setMobileOpen(!mobileOpen);
 
@@ -134,10 +135,20 @@ const Layout: React.FC = () => {
 
   const handleProfileMenuClose = () => setAnchorEl(null);
 
+  const handleSwitchUser = async () => {
+    handleProfileMenuClose();
+    try {
+      const { visualAuthAPI } = await import('../services/api');
+      await visualAuthAPI.deviceLogout();
+    } catch {}
+    await dispatch(logout());
+    navigate('/login');
+  };
+
   const handleLogout = async () => {
     await dispatch(logout());
     handleProfileMenuClose();
-    navigate('/login');
+    navigate('/login/classic');
   };
 
   const getPantryAriaLabel = () => {
@@ -321,6 +332,12 @@ const Layout: React.FC = () => {
                 <AccountCircleIcon fontSize="small" />
               </ListItemIcon>
               Profile
+            </MenuItem>
+            <MenuItem onClick={handleSwitchUser}>
+              <ListItemIcon>
+                <SwapHorizIcon fontSize="small" />
+              </ListItemIcon>
+              Switch User
             </MenuItem>
             <MenuItem onClick={handleLogout}>Logout</MenuItem>
           </Menu>

--- a/frontend/src/components/OnboardingWizard.tsx
+++ b/frontend/src/components/OnboardingWizard.tsx
@@ -135,7 +135,7 @@ const OnboardingWizard: React.FC<OnboardingWizardProps> = ({ open, onClose, onCo
           <Box sx={{ textAlign: 'center', py: 4 }}>
             <RestaurantIcon sx={{ fontSize: 80, color: 'primary.main', mb: 3 }} />
             <Typography variant="h4" gutterBottom>
-              Welcome to Meal Planner!
+              Welcome to Family Meal Planner!
             </Typography>
             <Typography variant="body1" color="text.secondary" sx={{ mb: 3, maxWidth: 500, mx: 'auto' }}>
               Let's personalize your experience in just a few quick steps. This will help us provide better recipe recommendations and meal planning suggestions.

--- a/frontend/src/components/RecipeDiscoveryEmptyState.tsx
+++ b/frontend/src/components/RecipeDiscoveryEmptyState.tsx
@@ -16,6 +16,7 @@ import {
   Stack,
   Skeleton,
   Container,
+  Alert,
 } from '@mui/material';
 import {
   Restaurant as RestaurantIcon,
@@ -148,12 +149,13 @@ const RecipeDiscoveryEmptyState: React.FC = () => {
   const [selectedRecipeId, setSelectedRecipeId] = useState<number | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
 
+  const [apiKeyMissing, setApiKeyMissing] = useState(false);
+
   useEffect(() => {
     const fetchSuggestions = async () => {
       try {
         setLoading(true);
-        
-        // Fetch trending recipes (popular)
+
         const trendingResult = await dispatch(
           searchSpoonacularRecipes({
             query: '',
@@ -162,8 +164,7 @@ const RecipeDiscoveryEmptyState: React.FC = () => {
             skipPaginationUpdate: true,
           })
         ).unwrap();
-        
-        // Fetch quick dinner recipes
+
         const quickResult = await dispatch(
           searchSpoonacularRecipes({
             query: 'dinner',
@@ -176,7 +177,12 @@ const RecipeDiscoveryEmptyState: React.FC = () => {
 
         setTrendingRecipes(trendingResult.results || []);
         setQuickDinners(quickResult.results || []);
-      } catch (error) {
+      } catch (error: unknown) {
+        const status = (error as { status?: number })?.status;
+        const message = String((error as { message?: string })?.message ?? '');
+        if (status === 400 || message.toLowerCase().includes('api key')) {
+          setApiKeyMissing(true);
+        }
         if (import.meta.env.DEV) console.error('Error fetching recipe suggestions:', error);
       } finally {
         setLoading(false);
@@ -290,6 +296,14 @@ const RecipeDiscoveryEmptyState: React.FC = () => {
               />
             ))}
           </Box>
+        ) : apiKeyMissing ? (
+          <Alert severity="info" action={
+            <Button size="small" color="inherit" onClick={() => navigate('/profile')}>
+              Set up API Key
+            </Button>
+          }>
+            Connect a Spoonacular API key in Admin → API Keys to browse thousands of recipes.
+          </Alert>
         ) : (
           <Typography color="text.secondary">
             No trending recipes available at the moment.

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -14,7 +14,6 @@ import {
   Skeleton,
   LinearProgress,
   Alert,
-  Snackbar,
   Paper,
   Tooltip,
 } from '@mui/material';
@@ -33,8 +32,6 @@ import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { fetchCurrentMealPlan } from '../store/slices/mealPlansSlice';
 import { fetchGroceryLists } from '../store/slices/groceryListsSlice';
 import { fetchExpiringItems, fetchLowStockItems } from '../store/slices/pantrySlice';
-import OnboardingWizard from '../components/OnboardingWizard';
-import type { OnboardingData } from '../components/OnboardingWizard';
 import { userAPI } from '../services/api';
 
 const getTimeOfDayGreeting = () => {
@@ -105,11 +102,20 @@ const TodayMeals = memo(({ loading, meals, onNavigate }: TodayMealsProps) => {
               ) : (
                 <Button
                   size="small"
-                  startIcon={<AddIcon sx={{ fontSize: 14 }} />}
+                  startIcon={<AddIcon sx={{ fontSize: 16 }} />}
                   onClick={onNavigate}
-                  sx={{ fontSize: '0.7rem', p: 0, minWidth: 0, mt: 0.5 }}
+                  sx={{
+                    fontSize: '0.8rem',
+                    minHeight: 44,
+                    minWidth: 44,
+                    mt: 0.5,
+                    border: '1px dashed',
+                    borderColor: 'divider',
+                    borderRadius: 1,
+                    width: '100%',
+                  }}
                 >
-                  Not planned
+                  Plan {slot}
                 </Button>
               )}
             </Box>
@@ -322,24 +328,10 @@ const Dashboard: React.FC = () => {
   const { expiringItems, lowStockItems, loading: pantryLoading } = useAppSelector((state) => state.pantry);
   const { user } = useAppSelector((state) => state.auth);
 
-  const [showOnboarding, setShowOnboarding] = useState(false);
   const [profileNudgeDismissed, setProfileNudgeDismissed] = useState(
     () => !!localStorage.getItem('profileNudgeDismissed')
   );
-  const [onboardingSnackbar, setOnboardingSnackbar] = useState<{ open: boolean; error: boolean }>({
-    open: false,
-    error: false,
-  });
 
-  useEffect(() => {
-    const onboardingCompleted = localStorage.getItem('onboardingCompleted');
-    if (!onboardingCompleted) {
-      const timer = setTimeout(() => setShowOnboarding(true), 500);
-      return () => clearTimeout(timer);
-    }
-  }, []);
-
-  // Fetch all dashboard data in parallel on mount
   useEffect(() => {
     dispatch(fetchCurrentMealPlan());
     dispatch(fetchGroceryLists({ status: 'shopping' }));
@@ -348,28 +340,6 @@ const Dashboard: React.FC = () => {
   }, [dispatch]);
 
   const handleNavigate = useCallback((path: string) => navigate(path), [navigate]);
-
-  const handleOnboardingComplete = async (data: OnboardingData) => {
-    localStorage.setItem('onboardingCompleted', 'true');
-    localStorage.setItem('onboardingData', JSON.stringify(data));
-    setShowOnboarding(false);
-
-    try {
-      // Persist onboarding preferences to backend
-      await userAPI.updatePreferences({
-        dietaryRestrictions: data.dietaryPreferences,
-        cookingSkillLevel: data.cookingSkillLevel,
-      });
-      setOnboardingSnackbar({ open: true, error: false });
-    } catch {
-      setOnboardingSnackbar({ open: true, error: true });
-    }
-  };
-
-  const handleOnboardingClose = () => {
-    localStorage.setItem('onboardingCompleted', 'true');
-    setShowOnboarding(false);
-  };
 
   const handleDismissNudge = () => {
     localStorage.setItem('profileNudgeDismissed', 'true');
@@ -401,7 +371,7 @@ const Dashboard: React.FC = () => {
 
   const showProfileNudge =
     !profileNudgeDismissed &&
-    !!localStorage.getItem('onboardingData') &&
+    !!localStorage.getItem('onboardingCompleted') &&
     !localStorage.getItem('profileNudgeDismissed');
 
   const familyName = user?.name ?? 'Family';
@@ -538,29 +508,6 @@ const Dashboard: React.FC = () => {
         </Grid>
       </Container>
 
-      <OnboardingWizard
-        open={showOnboarding}
-        onClose={handleOnboardingClose}
-        onComplete={handleOnboardingComplete}
-      />
-
-      <Snackbar
-        open={onboardingSnackbar.open}
-        autoHideDuration={6000}
-        onClose={() => setOnboardingSnackbar((s) => ({ ...s, open: false }))}
-        message={
-          onboardingSnackbar.error
-            ? 'Could not save preferences — visit Profile to complete setup'
-            : 'Your preferences were saved — you can update them in Profile any time'
-        }
-        action={
-          onboardingSnackbar.error ? (
-            <Button color="secondary" size="small" onClick={() => navigate('/profile')}>
-              Go to Profile
-            </Button>
-          ) : undefined
-        }
-      />
     </>
   );
 };

--- a/frontend/src/pages/LocalLogin.tsx
+++ b/frontend/src/pages/LocalLogin.tsx
@@ -21,15 +21,12 @@ import {
   Stepper,
   Step,
   StepLabel,
-  TextField,
-  Stack,
 } from '@mui/material';
 import { ArrowBack as ArrowBackIcon } from '@mui/icons-material';
 import { useAppDispatch } from '../store/hooks';
 import { setCredentials } from '../store/slices/authSlice';
-import api, { visualAuthAPI, authAPI } from '../services/api';
-import { isAxiosError } from 'axios';
-import { getApiErrorMessage } from '../utils/errorHandler';
+import api, { visualAuthAPI } from '../services/api';
+import { useTheme } from '@mui/material/styles';
 
 interface UserEntry {
   id: string;
@@ -42,12 +39,12 @@ interface ChallengeImage {
   imageUrl: string | null;
 }
 
-const STEPS_NORMAL = ['Who are you?', 'Pick your image'];
-const STEPS_SETUP  = ['Who are you?', 'Sign in to set up', 'Pick your image'];
+const STEPS = ['Who are you?', 'Pick your image'];
 
 const LocalLogin: React.FC = () => {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
+  const theme = useTheme();
 
   const [step, setStep] = useState(0);
   const [users, setUsers] = useState<UserEntry[]>([]);
@@ -58,24 +55,14 @@ const LocalLogin: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [verifying, setVerifying] = useState(false);
 
-  // Setup mode — entered when user has no visual password yet
-  const [setupMode, setSetupMode] = useState(false);
-  const [setupEmail, setSetupEmail] = useState('');
-  const [setupPassword, setSetupPassword] = useState('');
-  const [setupLoading, setSetupLoading] = useState(false);
-
-  const steps = setupMode ? STEPS_SETUP : STEPS_NORMAL;
-
-  // On mount: try device token first (silent, no UI flash)
   useEffect(() => {
     visualAuthAPI.deviceLogin()
       .then((res) => {
-        const { user } = res.data;
-        dispatch(setCredentials({ user: { ...user, name: user.name } }));
+        const { user, memberName } = res.data;
+        dispatch(setCredentials({ user: { ...user, name: memberName ?? user.name } }));
         navigate('/dashboard', { replace: true });
       })
       .catch(() => {
-        // No valid device token — show the normal picker
         loadUsers();
       });
   }, []);
@@ -91,8 +78,6 @@ const LocalLogin: React.FC = () => {
       }
       setUsers(userList);
     } catch {
-      // If the users endpoint fails, check whether this is a fresh install
-      // (no users exist). A server error on a fresh DB should still land on /welcome.
       try {
         const statusRes = await api.get('/auth/status');
         if (!statusRes.data.hasUsers) {
@@ -100,7 +85,7 @@ const LocalLogin: React.FC = () => {
           return;
         }
       } catch {
-        // status check also failed — server is genuinely unreachable
+        // Server genuinely unreachable
       }
       setError('Could not load users. Is the server running?');
     } finally {
@@ -116,82 +101,43 @@ const LocalLogin: React.FC = () => {
     try {
       const res = await visualAuthAPI.getVisualChallenge(user.id);
       setChallenge(res.data.images ?? []);
-      setSetupMode(false);
-    } catch (err: unknown) {
-      if (isAxiosError(err) && err.response?.status === 400) {
-        // No visual password set — enter first-time setup flow
-        setSetupMode(true);
-        setChallenge([]);
-      } else {
-        setError('Failed to load visual challenge. Please try again.');
-        setStep(0);
-        setSelectedUser(null);
-      }
+    } catch {
+      setError('Visual login not set up yet. Ask the admin to assign a login image from Profile → Family Members.');
+      setStep(0);
+      setSelectedUser(null);
     } finally {
       setChallengeLoading(false);
     }
   }, []);
 
-  const handleSetupSignIn = async () => {
-    setSetupLoading(true);
-    setError(null);
-    try {
-      const loginRes = await authAPI.login({ email: setupEmail, password: setupPassword });
-      dispatch(setCredentials({ user: loginRes.data.user }));
-
-      const imagesRes = await visualAuthAPI.getSetupImages();
-      const images = imagesRes.data.images ?? [];
-      if (images.length === 0) {
-        // Authenticated but no recipe images exist yet — send to dashboard so they can add one,
-        // then return here to complete visual login setup.
-        navigate('/dashboard', { replace: true, state: { visualLoginSetupPending: true } });
-        return;
-      }
-      setChallenge(images.map((r: { id: string; title: string; imageUrl: string }) => ({ id: r.id, title: r.title, imageUrl: r.imageUrl })));
-      setStep(2);
-    } catch (err: unknown) {
-      setError(getApiErrorMessage(err, 'Sign-in failed. Check your email and password.'));
-    } finally {
-      setSetupLoading(false);
-    }
-  };
-
-  const handlePickImage = useCallback(async (recipeId: string) => {
+  const handlePickImage = useCallback(async (imageId: string) => {
     if (!selectedUser || verifying) return;
     setVerifying(true);
     setError(null);
     try {
-      if (setupMode) {
-        await visualAuthAPI.setupVisualPassword(selectedUser.id, recipeId);
-        navigate('/dashboard', { replace: true });
-      } else {
-        const res = await visualAuthAPI.visualLogin({ memberId: selectedUser.id, recipeId });
-        const { user } = res.data;
-        dispatch(setCredentials({ user: { ...user, name: user.name } }));
-        const ftueDone = localStorage.getItem('mealplanner_member_ftue_done');
-        navigate(ftueDone ? '/dashboard' : '/member-welcome', { replace: true });
-      }
+      const res = await visualAuthAPI.visualLogin({ memberId: selectedUser.id, recipeId: imageId });
+      const { user, memberName } = res.data;
+      dispatch(setCredentials({ user: { ...user, name: memberName ?? user.name } }));
+      const ftueDone = localStorage.getItem(`mealplanner_member_ftue_done_${selectedUser.id}`);
+      navigate(ftueDone ? '/dashboard' : '/member-welcome', { replace: true });
     } catch {
-      setError(setupMode ? 'Failed to save. Please try again.' : 'Wrong image — tap the one you chose during setup.');
+      setError('Wrong image — tap the one you chose during setup.');
       setVerifying(false);
     }
-  }, [selectedUser, verifying, dispatch, navigate, setupMode]);
+  }, [selectedUser, verifying, dispatch, navigate]);
 
   const handleBack = () => {
     setStep(0);
     setSelectedUser(null);
     setChallenge([]);
     setError(null);
-    setSetupMode(false);
-    setSetupEmail('');
-    setSetupPassword('');
   };
 
   return (
     <Container maxWidth="sm" sx={{ py: 6 }}>
       <Box sx={{ textAlign: 'center', mb: 4 }}>
         <Typography variant="h4" gutterBottom>
-          Family Kitchen
+          Family Meal Planner
         </Typography>
         <Typography variant="body2" color="text.secondary">
           Tap your name, then pick your image
@@ -199,7 +145,7 @@ const LocalLogin: React.FC = () => {
       </Box>
 
       <Stepper activeStep={step} sx={{ mb: 4 }}>
-        {steps.map((label) => (
+        {STEPS.map((label) => (
           <Step key={label}>
             <StepLabel>{label}</StepLabel>
           </Step>
@@ -226,10 +172,7 @@ const LocalLogin: React.FC = () => {
                 <Skeleton key={i} variant="rectangular" height={120} sx={{ borderRadius: 2 }} />
               ))
             : users.map((user) => (
-                <Card
-                  key={user.id}
-                  sx={{ textAlign: 'center' }}
-                >
+                <Card key={user.id} sx={{ textAlign: 'center' }}>
                   <CardActionArea onClick={() => handleSelectUser(user)} sx={{ p: 2 }}>
                     <Avatar
                       sx={{
@@ -252,8 +195,8 @@ const LocalLogin: React.FC = () => {
         </Box>
       )}
 
-      {/* Step 1 (normal) — Visual challenge */}
-      {step === 1 && !setupMode && (
+      {/* Step 1 — Visual challenge */}
+      {step === 1 && (
         <Box>
           <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
             <Button
@@ -314,103 +257,11 @@ const LocalLogin: React.FC = () => {
         </Box>
       )}
 
-      {/* Step 1 (setup) — Sign in to authenticate before picking visual password */}
-      {step === 1 && setupMode && (
-        <Box>
-          <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
-            <Button startIcon={<ArrowBackIcon />} onClick={handleBack} size="small" sx={{ mr: 1 }}>
-              Back
-            </Button>
-            <Typography variant="body1">
-              First-time setup for <strong>{selectedUser?.name}</strong>
-            </Typography>
-          </Box>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-            Sign in with your account email and password, then pick a recipe image as your visual login.
-          </Typography>
-          <Stack spacing={2}>
-            <TextField
-              label="Email"
-              type="email"
-              fullWidth
-              value={setupEmail}
-              onChange={(e) => setSetupEmail(e.target.value)}
-              disabled={setupLoading}
-              autoComplete="email"
-            />
-            <TextField
-              label="Password"
-              type="password"
-              fullWidth
-              value={setupPassword}
-              onChange={(e) => setSetupPassword(e.target.value)}
-              disabled={setupLoading}
-              autoComplete="current-password"
-              onKeyDown={(e) => e.key === 'Enter' && !setupLoading && setupEmail && setupPassword && handleSetupSignIn()}
-            />
-            <Button
-              variant="contained"
-              fullWidth
-              onClick={handleSetupSignIn}
-              disabled={setupLoading || !setupEmail || !setupPassword}
-            >
-              {setupLoading ? <CircularProgress size={24} /> : 'Continue'}
-            </Button>
-          </Stack>
-        </Box>
-      )}
-
-      {/* Step 2 (setup) — Pick recipe as visual password */}
-      {step === 2 && setupMode && (
-        <Box>
-          <Typography variant="body1" sx={{ mb: 1 }}>
-            Pick your image, <strong>{selectedUser?.name}</strong>
-          </Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            Tap the recipe you want to use as your visual login. You'll tap it every time you sign in.
-          </Typography>
-          <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2, position: 'relative' }}>
-            {verifying && (
-              <Box
-                sx={{
-                  position: 'absolute',
-                  inset: 0,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  bgcolor: 'rgba(255,255,255,0.7)',
-                  zIndex: 1,
-                  borderRadius: 2,
-                }}
-              >
-                <CircularProgress />
-              </Box>
-            )}
-            {challenge.map((img) => (
-              <Card key={img.id} sx={{ cursor: 'pointer' }}>
-                <CardActionArea onClick={() => handlePickImage(img.id)} disabled={verifying}>
-                  <CardMedia
-                    component="img"
-                    height="160"
-                    image={img.imageUrl ?? '/placeholder-recipe.jpg'}
-                    alt={img.title}
-                    sx={{ objectFit: 'cover' }}
-                  />
-                  <CardContent sx={{ py: 1 }}>
-                    <Typography variant="caption" noWrap>{img.title}</Typography>
-                  </CardContent>
-                </CardActionArea>
-              </Card>
-            ))}
-          </Box>
-        </Box>
-      )}
-
       {/* Fallback to classic login */}
       <Box sx={{ textAlign: 'center', mt: 4 }}>
         <Typography variant="body2" color="text.secondary">
           Need email/password login?{' '}
-          <RouterLink to="/login/classic" style={{ color: 'inherit' }}>
+          <RouterLink to="/login/classic" style={{ color: theme.palette.primary.main }}>
             Classic sign-in
           </RouterLink>
         </Typography>
@@ -420,5 +271,3 @@ const LocalLogin: React.FC = () => {
 };
 
 export default LocalLogin;
-
-// Made with Bob

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -87,7 +87,7 @@ const Login: React.FC = () => {
       >
         <Paper elevation={3} sx={{ p: 4, width: '100%' }}>
           <Typography component="h1" variant="h4" align="center" gutterBottom>
-            Meal Planner
+            Family Meal Planner
           </Typography>
           <Typography component="h2" variant="h6" align="center" color="text.secondary" gutterBottom>
             Sign In

--- a/frontend/src/pages/MemberWelcome.tsx
+++ b/frontend/src/pages/MemberWelcome.tsx
@@ -16,7 +16,7 @@ import {
 } from '@mui/icons-material';
 import { useAppSelector } from '../store/hooks';
 
-const FTUE_KEY = 'mealplanner_member_ftue_done';
+const FTUE_KEY_PREFIX = 'mealplanner_member_ftue_done';
 
 interface Slide {
   icon: React.ReactNode;
@@ -30,6 +30,7 @@ export default function MemberWelcome() {
   const navigate = useNavigate();
   const theme = useTheme();
   const userName = useAppSelector((s) => s.auth.user?.name ?? 'there');
+  const userId = useAppSelector((s) => s.auth.user?.id);
   const [step, setStep] = useState(0);
 
   const slides: Slide[] = [
@@ -67,7 +68,9 @@ export default function MemberWelcome() {
   const current = slides[step];
 
   const finish = () => {
-    localStorage.setItem(FTUE_KEY, '1');
+    if (userId) {
+      localStorage.setItem(`${FTUE_KEY_PREFIX}_${userId}`, '1');
+    }
     navigate('/dashboard', { replace: true });
   };
 

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -141,7 +141,7 @@ const Register: React.FC = () => {
       >
         <Paper elevation={3} sx={{ p: 4, width: '100%' }}>
           <Typography component="h1" variant="h4" align="center" gutterBottom>
-            Meal Planner
+            Family Meal Planner
           </Typography>
           <Typography component="h2" variant="h6" align="center" color="text.secondary" gutterBottom>
             Create Account

--- a/frontend/src/pages/Setup.tsx
+++ b/frontend/src/pages/Setup.tsx
@@ -3,7 +3,7 @@
  * All rights reserved.
  */
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Box,
@@ -26,6 +26,17 @@ import {
   ListItem,
   ListItemText,
   ListItemSecondaryAction,
+  Card,
+  CardActionArea,
+  CardMedia,
+  CardContent,
+  FormControl,
+  FormLabel,
+  FormControlLabel,
+  RadioGroup,
+  Radio,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 import {
   Visibility,
@@ -34,28 +45,58 @@ import {
   Error as ErrorIcon,
   Delete as DeleteIcon,
   PersonAdd as PersonAddIcon,
+  ArrowBack as ArrowBackIcon,
 } from '@mui/icons-material';
-import api from '../services/api';
-import { familyMemberAPI } from '../services/api';
+import api, { familyMemberAPI, visualAuthAPI, userAPI } from '../services/api';
 import { getApiErrorMessage } from '../utils/errorHandler';
+import { DIETARY_PREFERENCES, COMMON_ALLERGENS, getDietaryLabel } from '../constants/dietaryOptions';
 
-const STEPS = ['Welcome', 'Family Members', 'Recipe API Key', 'Done'];
+const STEPS = ['Welcome', 'Family', 'Preferences', 'API Key', 'Done'];
+const STEPS_SHORT = ['Welcome', 'Family', 'Prefs', 'API', 'Done'];
+
+const CUISINE_OPTIONS = [
+  'Italian', 'Mexican', 'Chinese', 'Japanese', 'Indian',
+  'Thai', 'Mediterranean', 'American', 'French', 'Korean',
+];
 
 interface PendingMember {
   name: string;
   ageGroup: 'adult' | 'teen' | 'child';
 }
 
+interface StockImage {
+  id: string;
+  title: string;
+  imageUrl: string;
+}
+
+interface SavedMember {
+  id: string;
+  name: string;
+  visualPasswordImageUrl?: string;
+}
+
 export default function Setup() {
   const navigate = useNavigate();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [activeStep, setActiveStep] = useState(0);
 
   // Family members step
   const [members, setMembers] = useState<PendingMember[]>([]);
+  const [savedMembers, setSavedMembers] = useState<SavedMember[]>([]);
   const [memberName, setMemberName] = useState('');
   const [memberAgeGroup, setMemberAgeGroup] = useState<'adult' | 'teen' | 'child'>('adult');
   const [membersLoading, setMembersLoading] = useState(false);
   const [membersError, setMembersError] = useState('');
+  const [stockImages, setStockImages] = useState<StockImage[]>([]);
+  const [assigningMemberId, setAssigningMemberId] = useState<string | null>(null);
+
+  // Preferences step
+  const [dietaryPreferences, setDietaryPreferences] = useState<string[]>([]);
+  const [cuisinePreferences, setCuisinePreferences] = useState<string[]>([]);
+  const [cookingSkillLevel, setCookingSkillLevel] = useState('intermediate');
+  const [weeklyBudget, setWeeklyBudget] = useState('moderate');
 
   // Spoonacular step
   const [spoonacularKey, setSpoonacularKey] = useState('');
@@ -65,6 +106,12 @@ export default function Setup() {
   const [testMessage, setTestMessage] = useState('');
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState('');
+
+  useEffect(() => {
+    visualAuthAPI.getStockImages()
+      .then((res) => setStockImages(res.data.images ?? []))
+      .catch(() => {});
+  }, []);
 
   const handleAddMember = () => {
     const trimmed = memberName.trim();
@@ -79,29 +126,107 @@ export default function Setup() {
   };
 
   const handleSaveMembers = async () => {
+    if (members.length === 0 && savedMembers.length === 0) {
+      setActiveStep(2);
+      return;
+    }
     if (members.length === 0) {
       setActiveStep(2);
       return;
     }
+
     setMembersLoading(true);
     setMembersError('');
-    try {
-      await Promise.all(
-        members.map((m) =>
-          familyMemberAPI.create({
-            name: m.name,
-            ageGroup: m.ageGroup,
-            dietaryRestrictions: [],
-          })
-        )
-      );
-      setActiveStep(2);
-    } catch {
-      setMembersError('Some members could not be saved. You can add them later from Profile.');
-      setActiveStep(2);
-    } finally {
-      setMembersLoading(false);
+
+    const results = await Promise.allSettled(
+      members.map((m) =>
+        familyMemberAPI.create({
+          name: m.name,
+          ageGroup: m.ageGroup,
+          dietaryRestrictions: [],
+        })
+      )
+    );
+
+    const newSaved: SavedMember[] = [];
+    const failed: string[] = [];
+
+    results.forEach((result, i) => {
+      if (result.status === 'fulfilled') {
+        const data = result.value.data;
+        newSaved.push({ id: data.id, name: data.name ?? members[i].name });
+      } else {
+        failed.push(members[i].name);
+      }
+    });
+
+    setSavedMembers((prev) => [...prev, ...newSaved]);
+    setMembers(failed.map((name) => ({ name, ageGroup: 'adult' as const })));
+
+    if (failed.length > 0) {
+      setMembersError(`Could not save: ${failed.join(', ')}. You can retry or skip.`);
+    } else {
+      if (stockImages.length > 0 && newSaved.length > 0) {
+        setAssigningMemberId(newSaved[0].id);
+      } else {
+        setActiveStep(2);
+      }
     }
+
+    setMembersLoading(false);
+  };
+
+  const handleAssignVisualPassword = async (memberId: string, imageUrl: string) => {
+    try {
+      await visualAuthAPI.setupStockVisualPassword(memberId, imageUrl);
+      setSavedMembers((prev) =>
+        prev.map((m) => (m.id === memberId ? { ...m, visualPasswordImageUrl: imageUrl } : m))
+      );
+    } catch {
+      // Non-fatal — they can set it up later
+    }
+
+    // Move to next unassigned member or advance to next step
+    const unassigned = savedMembers.filter(
+      (m) => m.id !== memberId && !m.visualPasswordImageUrl
+    );
+    if (unassigned.length > 0) {
+      setAssigningMemberId(unassigned[0].id);
+    } else {
+      setAssigningMemberId(null);
+      setActiveStep(2);
+    }
+  };
+
+  const handleSkipVisualPassword = () => {
+    const current = savedMembers.find((m) => m.id === assigningMemberId);
+    const remaining = savedMembers.filter(
+      (m) => m.id !== assigningMemberId && !m.visualPasswordImageUrl
+    );
+    if (remaining.length > 0) {
+      setAssigningMemberId(remaining[0].id);
+    } else {
+      setAssigningMemberId(null);
+      setActiveStep(2);
+    }
+  };
+
+  const handleSavePreferences = async () => {
+    setSaving(true);
+    try {
+      const budgetMap: Record<string, number> = { budget: 75, moderate: 150, flexible: 250 };
+      await userAPI.updatePreferences({
+        dietaryRestrictions: dietaryPreferences,
+        cookingSkillLevel,
+        preferredCuisines: cuisinePreferences,
+        weeklyBudget: budgetMap[weeklyBudget] ?? 150,
+      });
+    } catch {
+      // Non-fatal — they can update from Profile
+    } finally {
+      setSaving(false);
+    }
+    setActiveStep(3);
   };
 
   const handleTestKey = async () => {
@@ -129,7 +254,8 @@ export default function Setup() {
         await api.put('/admin/settings/spoonacular_api_key', { value: spoonacularKey.trim() });
       }
       await api.put('/admin/settings/ftue_completed', { value: 'true' });
-      setActiveStep(3);
+      localStorage.setItem('onboardingCompleted', 'true');
+      setActiveStep(4);
     } catch (err: unknown) {
       setSaveError(getApiErrorMessage(err, 'Failed to save settings.'));
     } finally {
@@ -141,13 +267,25 @@ export default function Setup() {
     setSaving(true);
     try {
       await api.put('/admin/settings/ftue_completed', { value: 'true' });
+      localStorage.setItem('onboardingCompleted', 'true');
     } catch {
       // Proceed anyway
     } finally {
       setSaving(false);
     }
-    setActiveStep(3);
+    setActiveStep(4);
   };
+
+  const handleBack = () => {
+    if (assigningMemberId) {
+      setAssigningMemberId(null);
+      return;
+    }
+    setActiveStep((s) => Math.max(0, s - 1));
+  };
+
+  const stepLabels = isMobile ? STEPS_SHORT : STEPS;
+  const currentMemberName = savedMembers.find((m) => m.id === assigningMemberId)?.name;
 
   return (
     <Box
@@ -162,7 +300,6 @@ export default function Setup() {
     >
       <Container maxWidth="sm">
         <Paper sx={{ p: { xs: 3, sm: 5 }, borderRadius: 3 }} elevation={3}>
-          {/* Header */}
           <Box textAlign="center" mb={4}>
             <Typography variant="h4" fontWeight={700} gutterBottom>
               Family Meal Planner
@@ -172,8 +309,8 @@ export default function Setup() {
             </Typography>
           </Box>
 
-          <Stepper activeStep={activeStep} sx={{ mb: 5 }}>
-            {STEPS.map((label) => (
+          <Stepper activeStep={activeStep} alternativeLabel={isMobile} sx={{ mb: 4 }}>
+            {stepLabels.map((label) => (
               <Step key={label}>
                 <StepLabel>{label}</StepLabel>
               </Step>
@@ -187,40 +324,29 @@ export default function Setup() {
                 Welcome!
               </Typography>
               <Typography color="text.secondary" paragraph>
-                This wizard will help you connect optional external services that
-                unlock additional features.
-              </Typography>
-              <Typography color="text.secondary" paragraph>
-                The only optional integration right now is{' '}
-                <strong>Spoonacular</strong>, which powers the{' '}
-                <em>Browse Recipes</em> feature — letting you search millions of
-                recipes by ingredient, cuisine, or diet.
+                This wizard will walk you through setting up your family, preferences,
+                and optional integrations.
               </Typography>
               <Typography color="text.secondary">
-                You can skip any step and configure it later from the{' '}
-                <strong>Admin → API Keys</strong> page.
+                You can skip any step and configure it later from settings.
               </Typography>
               <Box mt={4} display="flex" justifyContent="flex-end">
-                <Button
-                  variant="contained"
-                  size="large"
-                  onClick={() => setActiveStep(1)}
-                >
-                  Get Started →
+                <Button variant="contained" size="large" onClick={() => setActiveStep(1)}>
+                  Get Started
                 </Button>
               </Box>
             </Box>
           )}
 
           {/* Step 1: Family Members */}
-          {activeStep === 1 && (
+          {activeStep === 1 && !assigningMemberId && (
             <Box>
               <Typography variant="h6" gutterBottom>
                 Who's in the family?
               </Typography>
               <Typography color="text.secondary" paragraph>
-                Add everyone who'll use the app. They'll log in by tapping their name and
-                picking their secret image — no password needed.
+                Add everyone who'll use the app. After saving, you'll pick a login
+                image for each person — no passwords needed.
               </Typography>
 
               {membersError && (
@@ -279,35 +405,204 @@ export default function Setup() {
                 </List>
               )}
 
-              <Alert severity="info" sx={{ mb: 3 }}>
-                Visual login images are picked from Profile → Family Members once you've added
-                some recipe photos. You can also set them up later.
-              </Alert>
+              {savedMembers.length > 0 && (
+                <Alert severity="success" sx={{ mb: 2 }}>
+                  Saved: {savedMembers.map((m) => m.name).join(', ')}
+                  {savedMembers.some((m) => m.visualPasswordImageUrl) && ' (with visual login)'}
+                </Alert>
+              )}
 
-              <Box display="flex" justifyContent="space-between" alignItems="center">
-                <Button
-                  variant="text"
-                  color="inherit"
-                  onClick={() => setActiveStep(2)}
-                  disabled={membersLoading}
-                >
-                  Skip
+              <Box display="flex" justifyContent="space-between" alignItems="center" mt={3}>
+                <Button variant="text" color="inherit" onClick={handleBack}>
+                  Back
                 </Button>
-                <Button
-                  variant="contained"
-                  size="large"
-                  onClick={handleSaveMembers}
-                  disabled={membersLoading}
-                  startIcon={membersLoading ? <CircularProgress size={16} /> : undefined}
-                >
-                  {membersLoading ? 'Saving…' : members.length > 0 ? 'Save & Continue' : 'Continue'}
+                <Box sx={{ display: 'flex', gap: 1 }}>
+                  <Button
+                    variant="text"
+                    color="inherit"
+                    onClick={() => setActiveStep(2)}
+                    disabled={membersLoading}
+                  >
+                    Skip
+                  </Button>
+                  <Button
+                    variant="contained"
+                    size="large"
+                    onClick={handleSaveMembers}
+                    disabled={membersLoading}
+                    startIcon={membersLoading ? <CircularProgress size={16} /> : undefined}
+                  >
+                    {membersLoading ? 'Saving…' : members.length > 0 ? 'Save & Continue' : 'Continue'}
+                  </Button>
+                </Box>
+              </Box>
+            </Box>
+          )}
+
+          {/* Step 1b: Visual password picker (shown after members are saved) */}
+          {activeStep === 1 && assigningMemberId && (
+            <Box>
+              <Typography variant="h6" gutterBottom>
+                Pick a login image for {currentMemberName}
+              </Typography>
+              <Typography color="text.secondary" paragraph>
+                {currentMemberName} will tap this image to sign in — no password needed.
+              </Typography>
+
+              <Box
+                sx={{
+                  display: 'grid',
+                  gridTemplateColumns: 'repeat(4, 1fr)',
+                  gap: 1.5,
+                  mb: 3,
+                }}
+              >
+                {stockImages.map((img) => (
+                  <Card key={img.id} sx={{ cursor: 'pointer' }}>
+                    <CardActionArea onClick={() => handleAssignVisualPassword(assigningMemberId, img.imageUrl)}>
+                      <CardMedia
+                        component="img"
+                        height="80"
+                        image={img.imageUrl}
+                        alt={img.title}
+                        sx={{ objectFit: 'cover' }}
+                      />
+                      <CardContent sx={{ py: 0.5, px: 1 }}>
+                        <Typography variant="caption" noWrap>{img.title}</Typography>
+                      </CardContent>
+                    </CardActionArea>
+                  </Card>
+                ))}
+              </Box>
+
+              <Box display="flex" justifyContent="space-between">
+                <Button variant="text" color="inherit" onClick={handleBack} startIcon={<ArrowBackIcon />}>
+                  Back
+                </Button>
+                <Button variant="text" color="inherit" onClick={handleSkipVisualPassword}>
+                  Skip for now
                 </Button>
               </Box>
             </Box>
           )}
 
-          {/* Step 2: Spoonacular API key */}
+          {/* Step 2: Preferences */}
           {activeStep === 2 && (
+            <Box>
+              <Typography variant="h6" gutterBottom>
+                Your preferences
+              </Typography>
+              <Typography color="text.secondary" paragraph>
+                Help us personalise recipes and meal plans. All optional.
+              </Typography>
+
+              <Typography variant="subtitle2" sx={{ mt: 1, mb: 1, fontWeight: 600 }}>
+                Dietary Preferences
+              </Typography>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
+                {DIETARY_PREFERENCES.map((option) => (
+                  <Chip
+                    key={option}
+                    label={option}
+                    onClick={() =>
+                      setDietaryPreferences((prev) =>
+                        prev.includes(option) ? prev.filter((p) => p !== option) : [...prev, option]
+                      )
+                    }
+                    color={dietaryPreferences.includes(option) ? 'primary' : 'default'}
+                    variant={dietaryPreferences.includes(option) ? 'filled' : 'outlined'}
+                  />
+                ))}
+              </Box>
+
+              <Typography variant="subtitle2" sx={{ mt: 1, mb: 1, fontWeight: 600, color: 'error.main' }}>
+                Food Allergens
+              </Typography>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
+                {COMMON_ALLERGENS.map((option) => (
+                  <Chip
+                    key={option}
+                    label={getDietaryLabel(option)}
+                    onClick={() =>
+                      setDietaryPreferences((prev) =>
+                        prev.includes(option) ? prev.filter((p) => p !== option) : [...prev, option]
+                      )
+                    }
+                    color={dietaryPreferences.includes(option) ? 'error' : 'default'}
+                    variant={dietaryPreferences.includes(option) ? 'filled' : 'outlined'}
+                  />
+                ))}
+              </Box>
+
+              <Typography variant="subtitle2" sx={{ mt: 2, mb: 1, fontWeight: 600 }}>
+                Favourite Cuisines
+              </Typography>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 3 }}>
+                {CUISINE_OPTIONS.map((cuisine) => (
+                  <Chip
+                    key={cuisine}
+                    label={cuisine}
+                    onClick={() =>
+                      setCuisinePreferences((prev) =>
+                        prev.includes(cuisine) ? prev.filter((c) => c !== cuisine) : [...prev, cuisine]
+                      )
+                    }
+                    color={cuisinePreferences.includes(cuisine) ? 'primary' : 'default'}
+                    variant={cuisinePreferences.includes(cuisine) ? 'filled' : 'outlined'}
+                  />
+                ))}
+              </Box>
+
+              <FormControl component="fieldset" sx={{ mb: 2, width: '100%' }}>
+                <FormLabel component="legend">Cooking skill level</FormLabel>
+                <RadioGroup
+                  row
+                  value={cookingSkillLevel}
+                  onChange={(e) => setCookingSkillLevel(e.target.value)}
+                >
+                  <FormControlLabel value="beginner" control={<Radio size="small" />} label="Beginner" />
+                  <FormControlLabel value="intermediate" control={<Radio size="small" />} label="Intermediate" />
+                  <FormControlLabel value="advanced" control={<Radio size="small" />} label="Advanced" />
+                </RadioGroup>
+              </FormControl>
+
+              <FormControl component="fieldset" sx={{ width: '100%' }}>
+                <FormLabel component="legend">Weekly grocery budget</FormLabel>
+                <RadioGroup
+                  row
+                  value={weeklyBudget}
+                  onChange={(e) => setWeeklyBudget(e.target.value)}
+                >
+                  <FormControlLabel value="budget" control={<Radio size="small" />} label="Under $100" />
+                  <FormControlLabel value="moderate" control={<Radio size="small" />} label="$100–200" />
+                  <FormControlLabel value="flexible" control={<Radio size="small" />} label="Over $200" />
+                </RadioGroup>
+              </FormControl>
+
+              <Box display="flex" justifyContent="space-between" alignItems="center" mt={3}>
+                <Button variant="text" color="inherit" onClick={handleBack}>
+                  Back
+                </Button>
+                <Box sx={{ display: 'flex', gap: 1 }}>
+                  <Button variant="text" color="inherit" onClick={() => setActiveStep(3)}>
+                    Skip
+                  </Button>
+                  <Button
+                    variant="contained"
+                    size="large"
+                    onClick={handleSavePreferences}
+                    disabled={saving}
+                    startIcon={saving ? <CircularProgress size={16} /> : undefined}
+                  >
+                    {saving ? 'Saving…' : 'Save & Continue'}
+                  </Button>
+                </Box>
+              </Box>
+            </Box>
+          )}
+
+          {/* Step 3: Spoonacular API key */}
+          {activeStep === 3 && (
             <Box>
               <Typography variant="h6" gutterBottom>
                 Spoonacular API Key
@@ -351,11 +646,7 @@ export default function Setup() {
               />
 
               {testResult === 'valid' && (
-                <Alert
-                  severity="success"
-                  icon={<CheckCircleIcon />}
-                  sx={{ mb: 2 }}
-                >
+                <Alert severity="success" icon={<CheckCircleIcon />} sx={{ mb: 2 }}>
                   {testMessage}
                 </Alert>
               )}
@@ -385,40 +676,37 @@ export default function Setup() {
               </Box>
 
               <Box display="flex" justifyContent="space-between" alignItems="center">
-                <Button
-                  variant="text"
-                  color="inherit"
-                  onClick={handleSkip}
-                  disabled={saving}
-                >
-                  Skip for now
+                <Button variant="text" color="inherit" onClick={handleBack}>
+                  Back
                 </Button>
-                <Button
-                  variant="contained"
-                  size="large"
-                  onClick={handleSaveAndContinue}
-                  disabled={saving || (!!spoonacularKey.trim() && testResult !== 'valid')}
-                  startIcon={saving ? <CircularProgress size={16} /> : undefined}
-                >
-                  {saving ? 'Saving…' : 'Save & Continue'}
-                </Button>
+                <Box sx={{ display: 'flex', gap: 1 }}>
+                  <Button variant="text" color="inherit" onClick={handleSkip} disabled={saving}>
+                    Skip for now
+                  </Button>
+                  <Button
+                    variant="contained"
+                    size="large"
+                    onClick={handleSaveAndContinue}
+                    disabled={saving || (!!spoonacularKey.trim() && testResult !== 'valid')}
+                    startIcon={saving ? <CircularProgress size={16} /> : undefined}
+                  >
+                    {saving ? 'Saving…' : 'Save & Continue'}
+                  </Button>
+                </Box>
               </Box>
-              <Typography variant="caption" color="text.secondary" display="block" mt={1}>
-                You must test and verify the key before saving, or leave the field empty to skip.
-              </Typography>
             </Box>
           )}
 
-          {/* Step 3: Done */}
-          {activeStep === 3 && (
+          {/* Step 4: Done */}
+          {activeStep === 4 && (
             <Box textAlign="center">
               <CheckCircleIcon color="success" sx={{ fontSize: 64, mb: 2 }} />
               <Typography variant="h6" gutterBottom>
                 You're all set!
               </Typography>
               <Typography color="text.secondary" paragraph>
-                Setup is complete. You can update API keys at any time from the{' '}
-                <strong>Admin → API Keys</strong> tab.
+                Setup is complete. You can update preferences and API keys any time
+                from the <strong>Profile</strong> and <strong>Admin</strong> pages.
               </Typography>
               <Button
                 variant="contained"

--- a/frontend/src/pages/Welcome.tsx
+++ b/frontend/src/pages/Welcome.tsx
@@ -261,6 +261,15 @@ const Welcome: React.FC = () => {
                   color={strengthColor()}
                   sx={{ height: 6, borderRadius: 3 }}
                 />
+                {passwordStrength < 50 && (
+                  <Typography variant="caption" color="error" sx={{ mt: 0.5, display: 'block' }}>
+                    Too weak to continue
+                    {password.length < 12 && ' — try a longer password'}
+                    {!/[A-Z]/.test(password) && ', add uppercase'}
+                    {!/\d/.test(password) && ', add a number'}
+                    {!/[^a-zA-Z\d]/.test(password) && ', add a symbol'}
+                  </Typography>
+                )}
               </Box>
             )}
             <TextField

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -139,8 +139,14 @@ export const visualAuthAPI = {
   setupVisualPassword: (familyMemberId: string, recipeId: string) =>
     api.post('/auth/visual-password/setup', { familyMemberId, recipeId }),
 
+  setupStockVisualPassword: (familyMemberId: string, imageUrl: string) =>
+    api.post('/auth/visual-password/setup-stock', { familyMemberId, imageUrl }),
+
   getSetupImages: () =>
     api.get('/auth/visual-setup/images'),
+
+  getStockImages: () =>
+    api.get('/auth/visual-setup/stock-images'),
 };
 
 // Recipe API
@@ -319,6 +325,8 @@ export const userAPI = {
     dietaryRestrictions?: string[];
     cookingSkillLevel?: string;
     avoidedIngredients?: string[];
+    preferredCuisines?: string[];
+    weeklyBudget?: number;
   }) => api.put('/users/preferences', data),
 };
 


### PR DESCRIPTION
## Summary

- Family members authenticate via visual login only — no email/password. Admin assigns visual passwords during setup using bundled stock food images
- Device cookie remembers which family member logged in — return visits skip the picker
- "Switch User" in profile menu to change active member
- Branding unified to "Family Meal Planner" (was 3 variants)
- OnboardingWizard merged into Setup wizard — all preferences now persist to backend
- 10+ UX fixes: touch targets, password hints, mobile stepper, Spoonacular empty state, profile nudge

## Test plan

- [ ] Playwright FTUE audit: `SKIP_GLOBAL_SETUP=1 BASE_URL=http://192.168.4.110 npx playwright test --project=ftue-audit`
- [ ] Fresh install: Tracy flow — tap name → pick stock image → dashboard
- [ ] Return visit: auto-login via device cookie, skip picker
- [ ] Switch user: profile menu → Switch User → member picker
- [ ] Setup wizard: all 5 steps with Back buttons, preferences save to backend

Epic: #231 | RFC: #248
Closes #232, #234, #235, #236, #237, #238, #239, #240, #241, #242, #243, #244, #245, #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)