### PR TITLE
feat(ingredients): fuzzy matching, duplicate prevention, and merge endpoint

### DIFF
--- a/backend/src/controllers/ingredient.controller.ts
+++ b/backend/src/controllers/ingredient.controller.ts
@@ -13,6 +13,14 @@ import logger from '../utils/logger';
 
 const INGREDIENT_CACHE_TTL = 3600; // 1 hour
 
+interface SimilarIngredientRow {
+  id: string;
+  name: string;
+  category: string;
+  unit: string;
+  sim_score: number;
+}
+
 /**
  * @route   GET /api/ingredients
  * @desc    Get all ingredients with optional filtering
@@ -152,12 +160,14 @@ export const createIngredient = async (
       allergens,
     } = req.body;
 
+    const { force } = req.query;
+
     // Validate required fields
     if (!name || !category || !unit || averagePrice === undefined) {
       throw new AppError('Name, category, unit, and average price are required', 400);
     }
 
-    // Check if ingredient already exists
+    // Check if ingredient already exists (exact match)
     const existing = await prisma.ingredient.findFirst({
       where: {
         name: {
@@ -169,6 +179,37 @@ export const createIngredient = async (
 
     if (existing) {
       throw new AppError('Ingredient with this name already exists', 409);
+    }
+
+    // Check for similar ingredients unless force=true
+    if (force !== 'true') {
+      const searchName = (name as string).trim().toLowerCase();
+      const similar = await prisma.$queryRaw<SimilarIngredientRow[]>`
+        SELECT id, name, category, unit,
+               similarity(lower(name), ${searchName}) as sim_score
+        FROM ingredients
+        WHERE similarity(lower(name), ${searchName}) > ${0.3}
+        ORDER BY sim_score DESC
+        LIMIT ${5}
+      `;
+
+      if (similar.length > 0) {
+        res.status(409).json({
+          success: false,
+          code: 'SIMILAR_EXISTS',
+          message: 'Similar ingredients already exist. Use force=true to create anyway.',
+          data: {
+            similar: similar.map((row: SimilarIngredientRow) => ({
+              id: row.id,
+              name: row.name,
+              category: row.category,
+              unit: row.unit,
+              similarity: parseFloat(Number(row.sim_score).toFixed(3)),
+            })),
+          },
+        });
+        return;
+      }
     }
 
     const ingredient = await prisma.ingredient.create({
@@ -435,6 +476,136 @@ export const getSearchSuggestions = async (
     await cacheSet(cacheKey, response, 300); // 5 min cache
 
     res.json(response);
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * @route   GET /api/ingredients/similar
+ * @desc    Find similar ingredients using trigram similarity
+ * @access  Public
+ */
+export const getSimilarIngredients = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const { name, threshold = '0.3', limit = '10' } = req.query;
+
+    if (!name || (name as string).length < 2) {
+      res.json({ success: true, data: [] });
+      return;
+    }
+
+    const searchName = (name as string).trim().toLowerCase();
+    const simThreshold = Math.max(0.1, Math.min(1, parseFloat(threshold as string)));
+    const limitNum = Math.min(20, Math.max(1, parseInt(limit as string)));
+
+    const cacheKey = `ingredient:similar:${searchName}:${simThreshold}:${limitNum}`;
+    const cached = await cacheGet(cacheKey);
+    if (cached) {
+      res.json(cached);
+      return;
+    }
+
+    const similar = await prisma.$queryRaw<SimilarIngredientRow[]>`
+      SELECT id, name, category, unit,
+             similarity(lower(name), ${searchName}) as sim_score
+      FROM ingredients
+      WHERE similarity(lower(name), ${searchName}) > ${simThreshold}
+        AND lower(name) != ${searchName}
+      ORDER BY sim_score DESC
+      LIMIT ${limitNum}
+    `;
+
+    const response = {
+      success: true,
+      data: similar.map((row: SimilarIngredientRow) => ({
+        id: row.id,
+        name: row.name,
+        category: row.category,
+        unit: row.unit,
+        similarity: parseFloat(Number(row.sim_score).toFixed(3)),
+      })),
+    };
+
+    await cacheSet(cacheKey, response, 300);
+
+    res.json(response);
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * @route   POST /api/ingredients/merge
+ * @desc    Merge a source ingredient into a target (reassign all references)
+ * @access  Private (Admin only)
+ */
+export const mergeIngredients = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const { sourceId, targetId } = req.body;
+
+    if (!sourceId || !targetId) {
+      throw new AppError('sourceId and targetId are required', 400);
+    }
+
+    if (sourceId === targetId) {
+      throw new AppError('Cannot merge an ingredient into itself', 400);
+    }
+
+    const [source, target] = await Promise.all([
+      prisma.ingredient.findUnique({ where: { id: sourceId } }),
+      prisma.ingredient.findUnique({ where: { id: targetId } }),
+    ]);
+
+    if (!source) throw new AppError('Source ingredient not found', 404);
+    if (!target) throw new AppError('Target ingredient not found', 404);
+
+    const result = await prisma.$transaction(async (tx) => {
+      const [recipes, grocery, pantry] = await Promise.all([
+        tx.recipeIngredient.updateMany({
+          where: { ingredientId: sourceId },
+          data: { ingredientId: targetId },
+        }),
+        tx.groceryListItem.updateMany({
+          where: { ingredientId: sourceId },
+          data: { ingredientId: targetId },
+        }),
+        tx.pantryInventory.updateMany({
+          where: { ingredientId: sourceId },
+          data: { ingredientId: targetId },
+        }),
+      ]);
+
+      await tx.ingredient.delete({ where: { id: sourceId } });
+
+      return {
+        recipesUpdated: recipes.count,
+        groceryItemsUpdated: grocery.count,
+        pantryItemsUpdated: pantry.count,
+      };
+    });
+
+    await cacheDelPattern('ingredient*');
+
+    logger.info(`Ingredient merged: ${source.name} (${sourceId}) → ${target.name} (${targetId})`, result);
+
+    res.json({
+      success: true,
+      message: `Merged "${source.name}" into "${target.name}"`,
+      data: {
+        source: { id: sourceId, name: source.name },
+        target: { id: targetId, name: target.name },
+        ...result,
+      },
+    });
   } catch (error) {
     next(error);
   }

--- a/backend/src/routes/ingredient.routes.ts
+++ b/backend/src/routes/ingredient.routes.ts
@@ -5,7 +5,8 @@
 
 
 import { Router } from 'express';
-import { optionalAuthenticate } from '../middleware/auth';
+import { authenticate, optionalAuthenticate } from '../middleware/auth';
+import { requireAdmin } from '../middleware/admin';
 import {
   getIngredients,
   getIngredientById,
@@ -14,6 +15,8 @@ import {
   deleteIngredient,
   getCategories,
   getSearchSuggestions,
+  getSimilarIngredients,
+  mergeIngredients,
 } from '../controllers/ingredient.controller';
 
 const router: Router = Router();
@@ -33,6 +36,13 @@ router.get('/categories', getCategories);
 router.get('/search/suggestions', getSearchSuggestions);
 
 /**
+ * @route   GET /api/ingredients/similar
+ * @desc    Find similar ingredients using trigram fuzzy matching
+ * @access  Public
+ */
+router.get('/similar', getSimilarIngredients);
+
+/**
  * @route   GET /api/ingredients
  * @desc    Get all ingredients with optional filtering
  * @access  Public
@@ -48,10 +58,17 @@ router.get('/:id', getIngredientById);
 
 /**
  * @route   POST /api/ingredients
- * @desc    Create new ingredient
+ * @desc    Create new ingredient (checks for similar ingredients unless force=true)
  * @access  Private (Admin only in production)
  */
 router.post('/', optionalAuthenticate, createIngredient);
+
+/**
+ * @route   POST /api/ingredients/merge
+ * @desc    Merge source ingredient into target (reassigns all references)
+ * @access  Private (Admin only)
+ */
+router.post('/merge', authenticate, requireAdmin, mergeIngredients);
 
 /**
  * @route   PUT /api/ingredients/:id

--- a/frontend/src/pages/CreateRecipe.tsx
+++ b/frontend/src/pages/CreateRecipe.tsx
@@ -3,7 +3,7 @@
  * All rights reserved.
  */
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
   Container,
@@ -49,6 +49,14 @@ interface Ingredient {
   name: string;
   category: string;
   unit: string;
+}
+
+interface SimilarIngredient {
+  id: string;
+  name: string;
+  category: string;
+  unit: string;
+  similarity: number;
 }
 
 interface RecipeIngredient {
@@ -147,6 +155,48 @@ export default function CreateRecipe() {
     unit: '',
     notes: '',
   });
+
+  const [similarIngredients, setSimilarIngredients] = useState<SimilarIngredient[]>([]);
+  const similarDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const fetchSimilarIngredients = useCallback(async (name: string) => {
+    if (name.length < 3) {
+      setSimilarIngredients([]);
+      return;
+    }
+    try {
+      const response = await api.get('/ingredients/similar', {
+        params: { name, threshold: 0.25, limit: 5 },
+      });
+      const data = response.data?.data || [];
+      setSimilarIngredients(data);
+    } catch {
+      setSimilarIngredients([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    const name = newIngredient.ingredientName.trim();
+    const hasExactMatch = newIngredient.ingredientId !== '';
+
+    if (hasExactMatch || name.length < 3) {
+      setSimilarIngredients([]);
+      return;
+    }
+
+    if (similarDebounceRef.current) {
+      clearTimeout(similarDebounceRef.current);
+    }
+    similarDebounceRef.current = setTimeout(() => {
+      fetchSimilarIngredients(name);
+    }, 400);
+
+    return () => {
+      if (similarDebounceRef.current) {
+        clearTimeout(similarDebounceRef.current);
+      }
+    };
+  }, [newIngredient.ingredientName, newIngredient.ingredientId, fetchSimilarIngredients]);
 
   useEffect(() => {
     loadIngredients();
@@ -758,6 +808,35 @@ export default function CreateRecipe() {
           </IconButton>
         </Grid>
       </Grid>
+
+      {similarIngredients.length > 0 && !newIngredient.ingredientId && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          <Typography variant="body2" sx={{ mb: 1 }}>
+            <strong>Similar ingredients already exist.</strong> Did you mean one of these?
+          </Typography>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+            {similarIngredients.map((sim) => (
+              <Chip
+                key={sim.id}
+                label={`${sim.name} (${Math.round(sim.similarity * 100)}% match)`}
+                size="small"
+                color="warning"
+                variant="outlined"
+                clickable
+                onClick={() => {
+                  setNewIngredient({
+                    ...newIngredient,
+                    ingredientId: sim.id,
+                    ingredientName: sim.name,
+                    unit: sim.unit || newIngredient.unit,
+                  });
+                  setSimilarIngredients([]);
+                }}
+              />
+            ))}
+          </Box>
+        </Alert>
+      )}
 
       <Typography variant="subtitle1" gutterBottom>
         Ingredients List ({formData.ingredients.length})


### PR DESCRIPTION
## Summary
- Add trigram similarity search endpoint (`GET /api/ingredients/similar`) for fuzzy ingredient lookup
- Duplicate prevention on `POST /api/ingredients` — returns similar matches unless `force=true`
- Admin merge endpoint (`POST /api/ingredients/merge`) that reassigns all recipe, grocery, and pantry references in a transaction before deleting the source
- Frontend similar-ingredient warnings in CreateRecipe autocomplete

Closes #18

## Test plan
- [ ] Create ingredient with a name similar to an existing one — verify 409 with `SIMILAR_EXISTS` and suggestion list
- [ ] Create with `?force=true` — verify it bypasses similarity check
- [ ] `GET /api/ingredients/similar?name=butr` — verify fuzzy results returned
- [ ] Merge two ingredients as admin — verify all references reassigned and source deleted
- [ ] Merge as non-admin — verify 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)