### PR TITLE
feat(logging): add structured logging, correlation IDs, and Loki aggregation

### DIFF
--- a/backend/src/middleware/logger.ts
+++ b/backend/src/middleware/logger.ts
@@ -4,6 +4,7 @@
  */
 
 
+import crypto from 'crypto';
 import { Request, Response, NextFunction } from 'express';
 import { logger } from '../utils/logger';
 
@@ -13,9 +14,13 @@ export function requestLogger(
   next: NextFunction
 ): void {
   const start = Date.now();
+  const correlationId = (req.headers['x-correlation-id'] as string) || crypto.randomUUID();
+
+  res.setHeader('x-correlation-id', correlationId);
 
   // Log request
   logger.info(`${req.method} ${req.path}`, {
+    correlationId,
     method: req.method,
     path: req.path,
     query: req.query,
@@ -29,10 +34,11 @@ export function requestLogger(
     const logLevel = res.statusCode >= 400 ? 'warn' : 'info';
 
     logger[logLevel](`${req.method} ${req.path} ${res.statusCode}`, {
+      correlationId,
       method: req.method,
       path: req.path,
       statusCode: res.statusCode,
-      duration: `${duration}ms`,
+      durationMs: duration,
       ip: req.ip,
     });
   });

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -25,6 +25,10 @@ const customFormat = winston.format.combine(
   winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
   winston.format.errors({ stack: true }),
   winston.format.splat(),
+  winston.format((info) => {
+    info.service = 'mealplanner-backend';
+    return info;
+  })(),
   winston.format.json()
 );
 

--- a/monitoring/grafana/provisioning/datasources/loki.yml
+++ b/monitoring/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false
+    editable: false

--- a/monitoring/loki.yml
+++ b/monitoring/loki.yml
@@ -1,0 +1,35 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: "2024-01-01"
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 72h
+  max_query_series: 500
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+  retention_enabled: true
+  delete_request_cancel_period: 10m

--- a/monitoring/promtail.yml
+++ b/monitoring/promtail.yml
@@ -1,0 +1,17 @@
+server:
+  http_listen_port: 9080
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: backend-logs
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: mealplanner-backend
+          __path__: /var/log/backend/*.log


### PR DESCRIPTION
## Summary
- Add structured JSON logging with correlation IDs to backend (`src/utils/logger.ts`, `src/middleware/logger.ts`)
- Add Loki + Promtail to the monitoring stack (`monitoring/loki.yml`, `monitoring/promtail.yml`, `monitoring/grafana/provisioning/`)
- Wire Loki datasource into Grafana via provisioning config

## Test plan
- [ ] Backend lint and type-check pass
- [ ] `podman-compose -f podman-compose.monitoring.yml up` starts Loki and Promtail without errors
- [ ] Backend logs appear in Grafana Explore → Loki datasource

🤖 Generated with [Claude Code](https://claude.com/claude-code)