### PR TITLE
fix(nginx): use Podman aardvark-dns resolver IP (#286)

### DIFF
--- a/ISSUE_PRIORITIES.md
+++ b/ISSUE_PRIORITIES.md
@@ -1,6 +1,6 @@
 # Issue Prioritization
 
-**Last Updated:** 2026-07-28 23:45:00 UTC
+**Last Updated:** 2026-07-29 02:17:59 UTC / 2026-07-28 21:17:59 CDT
 
 This file reflects the current state of GitHub issues organized by milestone and priority within each milestone.
 
@@ -13,10 +13,10 @@ a new milestone yet — all open issues below are unassigned. The items surfaced
 maintenance run (logs + CI audit) are the most urgent work regardless of milestone.
 
 ### 🔴 P0 - CRITICAL
-- #281 - All 4 ClusterHAT Zero W backend nodes crash-looping (~76k restarts) — Prisma engine built for wrong architecture
+- #281 - All 4 ClusterHAT Zero W backend nodes crash-looping (~76k restarts) — Prisma engine built for wrong architecture. **The fix this issue itself proposes does not work** — see note below.
 
 ### 🔴 P1 - HIGH
-- #286 - nginx resolver still hardcoded to Docker's 127.0.0.11 instead of Podman's 10.89.1.1 — breaks the Pi 4B fallback #281 currently depends on entirely
+- #286 - nginx resolver still hardcoded to Docker's 127.0.0.11 instead of Podman's 10.89.1.1 — breaks the Pi 4B fallback #281 currently depends on entirely. **Fix open in PR #287, unmerged.**
 - #282 - fix: backend/prisma/seed.ts still imports removed 'bcrypt' package, breaks e2e-tests DB seeding
 
 ### 🟡 P2 - MEDIUM
@@ -46,20 +46,43 @@ maintenance run (logs + CI audit) are the most urgent work regardless of milesto
 ### ⚠️ Needs a priority label
 - #261 - perf(e2e): use Playwright storageState to avoid per-test UI login in FTUE suite *(no priority/type labels — triage needed)*
 
-## 🔀 Open PRs (all stalled on CI, see #283/#282/#284 above for root causes)
-- #269 - chore(deps): MUI 7 → 9.1.2 *(open since 2026-07-02)*
-- #268 - chore(deps): Prisma 6 → 7.8.0 *(open since 2026-07-02)*
-- #267 - chore(deps): Express 4 → 5.2.1 *(open since 2026-07-02)*
-- #266 - chore(deps): TypeScript 5 → 6.0.3 *(open since 2026-07-02)*
-- #279 - chore(deps-dev): bump backend dev-deps group (8 updates) *(dependabot, open since 2026-07-27)*
-- #278 - chore(deps-dev): bump frontend dev-deps group (10 updates) *(dependabot, open since 2026-07-27)*
-- #277 - chore(deps): bump frontend prod-deps group (7 updates) *(dependabot, open since 2026-07-27)*
-- #276 - chore(deps): bump backend prod-deps group (3 updates) *(dependabot, open since 2026-07-20)*
+## 🔀 Open PRs
+- #287 - fix(nginx): use Podman aardvark-dns resolver IP (#286) *(opened 2026-07-29, this session)* — clean, targeted one-liner; see investigation note below for why it no longer also carries a #281 fix
+- #269 - chore(deps): MUI 7 → 9.1.2 *(open since 2026-07-02, stalled on CI)*
+- #268 - chore(deps): Prisma 6 → 7.8.0 *(open since 2026-07-02, stalled on CI)* — **worth a look for #281**: this branch's history (commit `a08ea2b`) upgrades to Prisma 7 with a `pg` driver adapter, which would sidestep the native/WASM-engine-binary problem entirely. Bundled with an unrelated major-version bump though — don't merge as-is just to get the adapter change.
+- #267 - chore(deps): Express 4 → 5.2.1 *(open since 2026-07-02, stalled on CI)*
+- #266 - chore(deps): TypeScript 5 → 6.0.3 *(open since 2026-07-02, stalled on CI)*
+- #279 - chore(deps-dev): bump backend dev-deps group (8 updates) *(dependabot, open since 2026-07-27, stalled on CI)*
+- #278 - chore(deps-dev): bump frontend dev-deps group (10 updates) *(dependabot, open since 2026-07-27, stalled on CI)*
+- #277 - chore(deps): bump frontend prod-deps group (7 updates) *(dependabot, open since 2026-07-27, stalled on CI)*
+- #276 - chore(deps): bump backend prod-deps group (3 updates) *(dependabot, open since 2026-07-20, stalled on CI)*
 
-All 8 show at least one red CI check. Root causes are now understood (#282 breaks `e2e-tests`
-for everything; #283 breaks install for Dependabot's own backend PRs specifically) — these
-should largely go green once #282 lands, and the #266/#267/#268/#269 branches likely just need
-a rebase onto main afterward.
+The 8 dependency-bump PRs each show at least one red CI check. Root causes are now understood
+(#282 breaks `e2e-tests` for everything; #283 breaks install for Dependabot's own backend PRs
+specifically) — these should largely go green once #282 lands, and the #266/#267/#268/#269
+branches likely just need a rebase onto main afterward.
+
+### Investigation note — 2026-07-29: #281's proposed fix doesn't work
+Opened PR #287 to fix both #281 and #286 together, then discovered while chasing CI failures on
+that PR that #281's own prescribed fix (add `linux-arm-openssl-3.0.x` to `binaryTargets`) is
+wrong: **Prisma 6.19.3 has no published query-engine binary for that target at all** (confirmed
+404 from `binaries.prisma.sh` for every OpenSSL variant). Adding it doesn't fix the Zero Ws — it
+breaks `prisma generate` everywhere, which is exactly what PR #287's CI caught.
+
+Also tried the `engineType = "wasm"` workaround sitting on orphaned branch `feat/ftue-cleanup-251`
+(commit `953d8d8`, authored 2026-07-01, never merged). Confirmed by actually generating the
+client that this **does not change runtime behavior either** — the generated `index.js` still
+embeds `"engineType": "library"` and would still try to load a missing native ARMv6 binary. That
+orphaned commit's "verified working" status (see [[project_zero_w_deployment]] in memory) looks
+like it was never actually true — #281's ~76k restarts started right around when that commit was
+authored and never stopped.
+
+**Conclusion:** a real fix needs Prisma's driver-adapter architecture (`@prisma/adapter-pg`,
+`previewFeatures = ["driverAdapters"]`, reworking `PrismaClient` instantiation in
+`backend/src/utils/prisma.ts`) — see the #268 note above, which already has this half-built as
+part of an unrelated Prisma 7 upgrade. This is a bigger change to the DB connection path used by
+every deployment target (not just the Zero Ws) and needs real testing before it ships. #281
+remains open and P0; PR #287 now only carries the #286 nginx fix.
 
 ## 📊 Weekly Maintenance Summary — 2026-07-28
 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider      = "prisma-client-js"
-  binaryTargets = ["native", "linux-musl-arm64-openssl-3.0.x", "linux-arm-openssl-3.0.x"]
+  binaryTargets = ["native", "linux-musl-arm64-openssl-3.0.x"]
   previewFeatures = ["metrics"]
 }
 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider      = "prisma-client-js"
-  binaryTargets = ["native", "linux-musl-arm64-openssl-3.0.x"]
+  binaryTargets = ["native", "linux-musl-arm64-openssl-3.0.x", "linux-arm-openssl-3.0.x"]
   previewFeatures = ["metrics"]
 }
 

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,4 +1,4 @@
-resolver 127.0.0.11 valid=10s ipv6=off;
+resolver 10.89.1.1 valid=10s ipv6=off;
 
 upstream backend_cluster {
     least_conn;


### PR DESCRIPTION
## Summary

**#286 — nginx resolver hardcoded to Docker's DNS instead of Podman's (fixed here):**
- `nginx/default.conf` had `resolver 127.0.0.11 ...` (Docker's embedded DNS) even though this project runs Podman, whose aardvark-dns binds to `10.89.1.1`.
- This breaks the variable-based `proxy_pass` in `@backend_local` (added in #206) from re-resolving `backend:3000` — the fallback path #281 currently depends on 100% while the Zero W cluster is down.
- Re-applies commit `4dcd96a`, a correct fix that only ever landed on an orphaned local branch (`feat/ftue-cleanup-251`) and never reached `main`.

**#281 — Zero W crash-loop (Prisma binary target): NOT fixed here, deferred.**

This PR originally also carried the fix the issue itself proposes (add `linux-arm-openssl-3.0.x` to `binaryTargets`). That turned out to be wrong, caught by this PR's own CI:

- Confirmed via `curl` against `binaries.prisma.sh` that **Prisma 6.19.3 has no published query-engine binary for `linux-arm-openssl-3.0.x` at all** (404, any OpenSSL variant). Adding it doesn't fix the Zero Ws — it breaks `prisma generate` everywhere (this PR's own backend Docker build and lint/type-check jobs failed on it).
- Also tried the `engineType = "wasm"` workaround sitting on an orphaned branch (commit `953d8d8`, authored 2026-07-01). Confirmed by inspecting the actually-generated client that this does **not** change runtime behavior — the generated `index.js` still embeds `"engineType": "library"` and would still try (and fail) to load a native ARMv6 binary. That orphaned commit was apparently never actually validated against the crash loop.
- A real fix needs Prisma's driver-adapter architecture (`@prisma/adapter-pg`, `previewFeatures = ["driverAdapters"]`, reworking `PrismaClient` instantiation in `backend/src/utils/prisma.ts`) — a bigger change to the DB connection path used by every deployment target, not just the Zero Ws, and one I don't want to ship without real testing. Tracked separately; #281 stays open.

## Test plan
- [ ] Merge and pull/redeploy nginx config to the Pi (`./scripts/pi-run.sh --clusterhat` or equivalent nginx reload)
- [ ] Force a `@backend_local` fallback (e.g. stop all Zero Ws, as is currently the case) and confirm `curl` through nginx to `/api/*` still resolves `backend:3000` instead of hanging
- [ ] `podman exec meals-nginx cat /etc/resolv.conf` — confirm it matches the configured resolver

🤖 Generated with [Claude Code](https://claude.com/claude-code)