### PR TITLE
fix(ci): pin packageManager so Dependabot regenerates lockfiles with same pnpm as CI

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,7 @@
   ],
   "author": "",
   "license": "PROPRIETARY",
+  "packageManager": "pnpm@11.1.2",
   "pnpm": {
     "onlyBuiltDependencies": [
       "@prisma/client",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "type": "module",
+  "packageManager": "pnpm@11.1.2",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
## Summary
- Root cause of #283: Dependabot's updater regenerates `pnpm-lock.yaml` with its own bundled pnpm, which unconditionally serializes the top-level `overrides:` block whenever `package.json` declares `pnpm.overrides`. CI's pinned `pnpm@11.1.2` only writes that block when an override actually affects resolution — confirmed locally that `main`'s committed `backend/pnpm-lock.yaml` has no `overrides:` block, and running `pnpm install --no-frozen-lockfile` under 11.1.2 on a Dependabot branch strips the block back out. That serialization mismatch is exactly what `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` flags during `pnpm install --frozen-lockfile`.
- Fix: add `"packageManager": "pnpm@11.1.2"` to `backend/package.json` and `frontend/package.json`, matching the version `.github/workflows/ci.yml` already pins via `pnpm/action-setup`. Dependabot's `npm_and_yarn` updater reads this field to select its own pnpm version, so it will now produce lockfiles identical to what CI expects.
- Pinned frontend too since it has the same `pnpm.overrides` pattern (just hasn't tripped the mismatch yet, likely because none of its override targets have been pulled transitively by a recent bump).

## Reproduction
Confirmed locally against the existing Dependabot branches:
- `dependabot/npm_and_yarn/backend/prod-deps-bd8780f675` (#276) and `.../dev-deps-99da30af27` (#279) both fail `pnpm install --frozen-lockfile` with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`, matching the CI logs cited in #283.
- After adding the `packageManager` pin, `pnpm install --frozen-lockfile` succeeds cleanly against `main`'s current lockfiles for both `backend/` and `frontend/`.

## Follow-up (not done here — touches PRs this change doesn't own)
Once this merges, #276 and #279 are still on lockfiles generated by the old (unpinned) Dependabot updater and need to pick up the fix. Recommend commenting `@dependabot recreate` on both after merge, or just letting their next scheduled Monday run rebase them.

## Test plan
- [x] `pnpm install --frozen-lockfile` passes in `backend/` against this branch
- [x] `pnpm install --frozen-lockfile` passes in `frontend/` against this branch
- [x] Reproduced the original failure against `dependabot/npm_and_yarn/backend/prod-deps-bd8780f675` before the fix
- [ ] CI green on this PR (frontend/backend lint+typecheck jobs run `pnpm install --frozen-lockfile`, will confirm here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)