### PR TITLE
fix: seed.ts still imports removed bcrypt package

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -4,7 +4,7 @@
  */
 
 import { PrismaClient } from '@prisma/client';
-import * as bcrypt from 'bcrypt';
+import bcrypt from 'bcryptjs';
 
 const prisma = new PrismaClient();
 


### PR DESCRIPTION
## Summary
- `backend/prisma/seed.ts` still imported the removed `bcrypt` package after PR #262 switched everything else in `backend/` to `bcryptjs`
- This broke `ts-node` compilation of the seed script, blocking the `e2e-tests` CI job's `Setup database` step on every run since 2026-07-01
- Swapped to `import bcrypt from 'bcryptjs'`, matching the pattern already used in `src/controllers/admin.controller.ts` and `src/controllers/auth.controller.ts`

## Test plan
- [x] `pnpm install --frozen-lockfile` + `npx prisma generate` + `npx tsc --noEmit -p .` in `backend/` — clean, no errors (confirmed the only pre-fix errors were from missing generated Prisma client, unrelated to this change; targeted grep for `seed.ts`/`bcrypt` errors before the client was even generated also came back empty)
- [x] Confirmed `bcryptjs` is already a `backend/package.json` dependency (`^2.4.3`) and `@types/bcryptjs` is a devDependency

Fixes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)