### PR TITLE
fix(ci): copy pnpm-workspace.yaml into Docker build context

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,10 +9,11 @@
 # Stages 1 and 2 run on the native amd64 GitHub runner (no QEMU). Stage 3
 # inherits the target platform from `docker buildx --platform linux/arm64`.
 #
-# pnpm@11 blocks build scripts by default. onlyBuiltDependencies in the lockfile
-# settings section explicitly approves the packages that need native compilation
-# or postinstall hooks (bcrypt, Prisma). This setting is read by every pnpm
-# invocation including subprocess calls from prisma generate.
+# pnpm@10+ blocks build scripts by default. allowBuilds in pnpm-workspace.yaml
+# explicitly approves the packages that need native compilation or postinstall
+# hooks (Prisma). This setting is read by every pnpm invocation including
+# subprocess calls from prisma generate — but only if pnpm-workspace.yaml is
+# actually present in the build context (see the COPY steps below, #290).
 
 # ============================================================================
 # STAGE 1/3: Frontend Builder  [BUILD ARCH: amd64]
@@ -23,9 +24,17 @@ FROM --platform=linux/amd64 docker.io/library/node:22-alpine AS frontend-builder
 
 WORKDIR /frontend
 
-COPY frontend/package.json frontend/pnpm-lock.yaml ./
+# pnpm-workspace.yaml carries the allowBuilds allow-list (pnpm 10+ requires
+# explicit build-script approval and treats a missing approval as a hard
+# error with no TTY to prompt in); omitting it from the build context fails
+# `pnpm install` with ERR_PNPM_IGNORED_BUILDS even though esbuild is
+# allow-listed in package.json (see #290).
+COPY frontend/package.json frontend/pnpm-lock.yaml frontend/pnpm-workspace.yaml ./
 
-RUN npm install -g pnpm@10 --quiet
+# Version pinned to match packageManager in frontend/package.json — a
+# floating major tag (pnpm@10) can silently re-resolve to a newer patch
+# release with different build-script enforcement behavior (see #290).
+RUN npm install -g pnpm@11.1.2 --quiet
 
 RUN pnpm install --no-frozen-lockfile --prod=false
 
@@ -53,12 +62,18 @@ RUN apk add --no-cache python3 make g++ gcc
 
 WORKDIR /app
 
-COPY backend/package.json backend/pnpm-lock.yaml ./
+# pnpm-workspace.yaml carries the allowBuilds allow-list (pnpm 10+ requires
+# explicit build-script approval and treats a missing approval as a hard
+# error with no TTY to prompt in); omitting it from the build context fails
+# `pnpm install` with ERR_PNPM_IGNORED_BUILDS even though Prisma is
+# allow-listed in package.json (see #290).
+COPY backend/package.json backend/pnpm-lock.yaml backend/pnpm-workspace.yaml ./
 
-RUN npm install -g pnpm@10 --quiet
+# Version pinned to match packageManager in backend/package.json — a
+# floating major tag (pnpm@10) can silently re-resolve to a newer patch
+# release with different build-script enforcement behavior (see #290).
+RUN npm install -g pnpm@11.1.2 --quiet
 
-# onlyBuiltDependencies in the lockfile settings allows bcrypt and Prisma
-# packages to run their install scripts; all others remain blocked.
 RUN pnpm install --no-frozen-lockfile
 
 COPY backend .

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,15 +7,19 @@ FROM --platform=linux/amd64 docker.io/library/node:22-alpine AS builder
 
 WORKDIR /app
 
-# Copy package files
-COPY package.json pnpm-lock.yaml ./
+# Copy package files. pnpm-workspace.yaml must come along — it carries the
+# allowBuilds allow-list (pnpm 10+ requires explicit build-script approval,
+# and rejects it as a hard error with no TTY to prompt in). Without this file
+# in the build context, `pnpm install` fails with ERR_PNPM_IGNORED_BUILDS
+# even though esbuild is allow-listed in package.json (see #290).
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
-# pnpm version must match local dev environment (lockfile was generated with pnpm@11)
-RUN npm install -g pnpm@10 --quiet
+# Version pinned to match packageManager in package.json — a floating major
+# tag (pnpm@10) can silently re-resolve to a newer patch release with
+# different build-script enforcement behavior (see #290).
+RUN npm install -g pnpm@11.1.2 --quiet
 
 # Install dependencies (build only, no dev dependencies needed in final image)
-# onlyBuiltDependencies in the lockfile settings allows esbuild to run its
-# install script; the setting propagates to all pnpm subprocess calls too.
 RUN pnpm install --no-frozen-lockfile --prod=false
 
 # Copy source code


### PR DESCRIPTION
## Summary
- Fixes #290 — `build-and-push` failing on both frontend and backend Docker builds with `ERR_PNPM_IGNORED_BUILDS`.
- Root cause: neither Dockerfile ever copied `pnpm-workspace.yaml` into the build context before running `pnpm install`. That file carries the `allowBuilds` allow-list pnpm 10+ requires for build-script approval; without it, pnpm treats the approval as missing and hard-fails (`ERR_PNPM_IGNORED_BUILDS`) in the non-interactive Docker build — even though the same packages are listed in `onlyBuiltDependencies` in `package.json`.
- This is why pinning the pnpm version alone (already done on #266) doesn't fix CI there either — the missing file, not the floating version tag, is the actual cause.
- Also pins the pnpm install in both Dockerfiles to the exact version in `packageManager` (`pnpm@11.1.2`) instead of the floating `pnpm@10` tag, so a future pnpm patch release can't silently change build-script enforcement under CI again.

## Verification
- Reproduced locally: ran `pnpm install --no-frozen-lockfile` against `frontend/pnpm-lock.yaml` with pnpm 11.1.2 — fails with `ERR_PNPM_IGNORED_BUILDS` without `pnpm-workspace.yaml` present, succeeds once it's included.
- Built both Dockerfiles' builder stages end-to-end with `podman build` (frontend `builder` target, backend `backend-builder` target, which also exercises the `frontend-builder` stage) — both complete cleanly with no ignored-builds error.

## Note for reviewers
PR #266 (`chore/ts6-upgrade`) independently added the `pnpm@10` → `pnpm@11.1.2` pin to both Dockerfiles but not the `pnpm-workspace.yaml` copy, so its `build-and-push` checks are still red. Once this merges, #266 will need a rebase — the pin lines should merge cleanly since they're now identical, but worth flagging so whoever picks that PR back up isn't confused by lingering CI failures there.

## Test plan
- [x] `podman build --target builder` (frontend) succeeds, no `ERR_PNPM_IGNORED_BUILDS`
- [x] `podman build --target backend-builder` (backend, includes frontend-builder stage) succeeds, no `ERR_PNPM_IGNORED_BUILDS`
- [ ] CI `build-and-push` passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)