### PR TITLE
fix(frontend): match frontend User type to backend familyName field

### DIFF
--- a/frontend/src/__tests__/store/authSlice.test.ts
+++ b/frontend/src/__tests__/store/authSlice.test.ts
@@ -12,7 +12,7 @@ import type { User } from '../../store/slices/authSlice';
 const mockUser: User = {
   id: '1',
   email: 'test@example.com',
-  name: 'Test User',
+  familyName: 'Test Family',
   role: 'user',
   createdAt: '2026-01-01T00:00:00Z',
   updatedAt: '2026-01-01T00:00:00Z',

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -43,7 +43,7 @@ import {
 } from '@mui/icons-material';
 import { useThemePreference } from '../contexts/ThemeContext';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
-import { logout } from '../store/slices/authSlice';
+import { logout, getDisplayName } from '../store/slices/authSlice';
 import { fetchExpiringItems, fetchLowStockItems } from '../store/slices/pantrySlice';
 import { fetchGroceryLists } from '../store/slices/groceryListsSlice';
 import BackendStatusBanner from './BackendStatusBanner';
@@ -119,7 +119,7 @@ const Layout: React.FC = () => {
   const groceryUnchecked = activeGroceryList?.items.filter((i) => !i.isChecked).length ?? 0;
 
   // ── Family identity ──────────────────────────────────────────────────────
-  const familyName = user?.name ?? 'Family';
+  const familyName = getDisplayName(user, 'Family');
   const drawerTitle = `${familyName}'s Meal Planner`;
 
   const handleDrawerToggle = () => setMobileOpen(!mobileOpen);
@@ -316,7 +316,7 @@ const Layout: React.FC = () => {
               color="inherit"
             >
               <Avatar sx={{ width: 32, height: 32, bgcolor: 'secondary.main' }}>
-                {user?.name?.charAt(0).toUpperCase() || 'U'}
+                {getDisplayName(user, 'U').charAt(0).toUpperCase()}
               </Avatar>
             </IconButton>
           </Tooltip>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -30,6 +30,7 @@ import { useTheme } from '@mui/material/styles';
 import { format, startOfWeek, addDays, isSameDay } from 'date-fns';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { fetchCurrentMealPlan } from '../store/slices/mealPlansSlice';
+import { getDisplayName } from '../store/slices/authSlice';
 import { fetchGroceryLists } from '../store/slices/groceryListsSlice';
 import { fetchExpiringItems, fetchLowStockItems } from '../store/slices/pantrySlice';
 
@@ -372,7 +373,7 @@ const Dashboard: React.FC = () => {
     !profileNudgeDismissed &&
     !!localStorage.getItem('onboardingCompleted');
 
-  const familyName = user?.name ?? 'Family';
+  const familyName = getDisplayName(user, 'Family');
   const greeting = `Good ${getTimeOfDayGreeting()}, ${familyName}`;
 
   const quickActions = [

--- a/frontend/src/pages/LocalLogin.tsx
+++ b/frontend/src/pages/LocalLogin.tsx
@@ -59,7 +59,11 @@ const LocalLogin: React.FC = () => {
     visualAuthAPI.deviceLogin()
       .then((res) => {
         const { user, memberName } = res.data;
-        dispatch(setCredentials({ user: { ...user, name: memberName ?? user.name } }));
+        // `memberName` is the selected family member's own name, distinct from the
+        // household `familyName` the backend sends elsewhere on `user`. Track it
+        // separately so personalized UI (sidebar/avatar) can show the member without
+        // clobbering the account's actual family name (see issue #300).
+        dispatch(setCredentials({ user: { ...user, displayName: memberName ?? user.name } }));
         navigate('/dashboard', { replace: true });
       })
       .catch(() => {
@@ -117,7 +121,9 @@ const LocalLogin: React.FC = () => {
     try {
       const res = await visualAuthAPI.visualLogin({ memberId: selectedUser.id, recipeId: imageId });
       const { user, memberName } = res.data;
-      dispatch(setCredentials({ user: { ...user, name: memberName ?? user.name } }));
+      // See comment in the deviceLogin handler above — `displayName` tracks the
+      // individual member, keeping `familyName` (household name) untouched.
+      dispatch(setCredentials({ user: { ...user, displayName: memberName ?? user.name } }));
       const ftueDone = localStorage.getItem(`mealplanner_member_ftue_done_${selectedUser.id}`);
       navigate(ftueDone ? '/dashboard' : '/member-welcome', { replace: true });
     } catch {

--- a/frontend/src/pages/MemberWelcome.tsx
+++ b/frontend/src/pages/MemberWelcome.tsx
@@ -15,6 +15,7 @@ import {
   KeyboardArrowLeft,
 } from '@mui/icons-material';
 import { useAppSelector } from '../store/hooks';
+import { getDisplayName } from '../store/slices/authSlice';
 
 const FTUE_KEY_PREFIX = 'mealplanner_member_ftue_done';
 
@@ -29,7 +30,7 @@ interface Slide {
 export default function MemberWelcome() {
   const navigate = useNavigate();
   const theme = useTheme();
-  const userName = useAppSelector((s) => s.auth.user?.name ?? 'there');
+  const userName = useAppSelector((s) => getDisplayName(s.auth.user, 'there'));
   const userId = useAppSelector((s) => s.auth.user?.id);
   const [step, setStep] = useState(0);
 

--- a/frontend/src/store/slices/authSlice.ts
+++ b/frontend/src/store/slices/authSlice.ts
@@ -12,10 +12,28 @@ import { getApiErrorMessage } from '../../utils/errorHandler';
 export interface User {
   id: string;
   email: string;
-  name: string;
+  /** Household/family name, as sent by the backend (`formatUserResponse`). */
+  familyName: string;
+  /**
+   * Individual family member's display name. Client-only — never sent by the
+   * classic login/register/session-bootstrap endpoints. Set by the visual
+   * "member tile" / device login flow (see `LocalLogin.tsx`) so personalized
+   * UI (sidebar brand, avatar initial, FTUE greeting) can show the selected
+   * member's name without overwriting the household `familyName`.
+   */
+  displayName?: string;
   role: string;
   createdAt: string;
   updatedAt: string;
+}
+
+/**
+ * Best available name for personalized UI: prefers the individual family
+ * member's name (set during the member-tile login flow) and falls back to
+ * the household family name, then to the caller-supplied default.
+ */
+export function getDisplayName(user: User | null | undefined, fallback: string): string {
+  return user?.displayName ?? user?.familyName ?? fallback;
 }
 
 interface AuthState {


### PR DESCRIPTION
## Problem

The frontend `User` type in `frontend/src/store/slices/authSlice.ts` declared `name: string`, but the backend never sends that field — every serialization path in `backend/src/controllers/auth.controller.ts` (`formatUserResponse`, login, register, session bootstrap) sends `familyName` instead, matching the Prisma `User` model. `user?.name` was therefore always `undefined` for classic login, and the `?? 'Family'` / `|| 'U'` fallbacks silently masked it — the sidebar brand title, AppBar avatar initial, Dashboard greeting, and `MemberWelcome` FTUE greeting never personalized.

## Fix

- Renamed `User.name` → `User.familyName` in `authSlice.ts` to match the backend's actual response shape.
- Updated read call sites: `Layout.tsx` (drawer brand title, AppBar avatar initial), `Dashboard.tsx` (greeting), `MemberWelcome.tsx` (FTUE greeting).
- Updated `authSlice.test.ts`'s mock user to use `familyName`.

### Handling the `LocalLogin.tsx` member-tile semantic conflict

`LocalLogin.tsx`'s member-tile (visual/device login) flow previously patched the *individual family member's* name into `user.name` client-side (`{ ...user, name: memberName ?? user.name }`), which is why member tiles already showed personalized names correctly. Naively renaming `name` → `familyName` there would make that patch overwrite the *household* family name with an individual member's name — semantically wrong, and it would silently corrupt `familyName` for the rest of the session (e.g. anything reading it later).

Instead:
- Added a distinct, client-only `User.displayName?: string` field, documented as "never sent by the classic login/register/session-bootstrap endpoints; set by the visual member-tile / device login flow."
- `LocalLogin.tsx` now sets `displayName` (not `familyName`) to the selected member's name in both the device-login and visual-login handlers.
- Added a small `getDisplayName(user, fallback)` helper in `authSlice.ts` that prefers `displayName` over `familyName` (then the caller's fallback), used consistently by `Layout.tsx`, `Dashboard.tsx`, and `MemberWelcome.tsx`.

This preserves the member-tile flow's current visible behavior (sidebar/avatar/greeting show the selected member) without conflating "household family name" and "individual member name," and without clobbering `familyName` anywhere it's read (e.g. `/profile`, which fetches it independently via its own API call rather than from Redux).

I considered the issue's suggestion of a shared/generated type or runtime validation to catch this class of drift, but that would mean introducing new codegen/validation tooling this repo doesn't already have — out of scope for a small, targeted fix. The TS-level type rename (matching what the backend actually returns) directly addresses the root cause.

## Validation

- `npm run build` (tsc -b && vite build) — passes clean for all files touched by this change. (One pre-existing unrelated `tsc` error in `authSlice.test.ts` from the `name` → `familyName` rename was fixed as part of this PR.)
- `npm run lint` — no new lint errors introduced. The lint run does surface some pre-existing errors in unrelated files (`AdminDashboard.tsx`, `MealPlanner.tsx`, `Profile.tsx`, `RecipeDetail.tsx`, `GroceryList.tsx`, and a pre-existing `loadUsers`-declared-after-use issue in `LocalLogin.tsx` that predates this change, confirmed via `git show HEAD:...`) — none are in the files this PR modifies.
- Live browser QA (logging in as `test@example.com` and visually confirming "Test Family's Meal Planner" / avatar "T", then exercising the member-tile flow and `/profile`) was **not** performed — no browser/screenshot tooling is available in this environment. The fix was instead verified by a careful read-through of `formatUserResponse`, `visualAuth.controller.ts` (`visualLogin`/`deviceLogin` response shapes), and every frontend call site, plus a clean production build/lint.

Fixes #300