### PR TITLE
fix(frontend): wire Pantry page to real pantry API/Redux slice

### DIFF
--- a/frontend/src/pages/Pantry.tsx
+++ b/frontend/src/pages/Pantry.tsx
@@ -4,7 +4,7 @@
  */
 
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Container,
   Typography,
@@ -30,6 +30,8 @@ import {
   Alert,
   Tabs,
   Tab,
+  CircularProgress,
+  Autocomplete,
 } from '@mui/material';
 import {
   Add as AddIcon,
@@ -38,134 +40,221 @@ import {
   Warning as WarningIcon,
   Kitchen as KitchenIcon,
 } from '@mui/icons-material';
+import { useAppDispatch, useAppSelector } from '../store/hooks';
+import {
+  fetchPantryItems,
+  fetchLowStockItems,
+  fetchExpiringItems,
+  addPantryItem,
+  updatePantryItem,
+  deletePantryItem,
+  clearError,
+} from '../store/slices/pantrySlice';
+import type { PantryItem } from '../store/slices/pantrySlice';
+import { ingredientAPI } from '../services/api';
+import { getApiErrorMessage } from '../utils/errorHandler';
 
-interface PantryItem {
+interface IngredientOption {
   id: string;
   name: string;
-  quantity: number;
-  unit: string;
   category: string;
-  location: string;
-  expirationDate?: string;
-  minQuantity: number;
 }
 
-const CATEGORIES = [
-  'Grains & Pasta',
-  'Canned Goods',
-  'Spices & Seasonings',
-  'Oils & Condiments',
-  'Baking',
-  'Snacks',
-  'Beverages',
-  'Other',
+// Mirrors the store-section categories used elsewhere (e.g. GroceryList.tsx)
+// so ingredients created here stay consistent with the rest of the app.
+const INGREDIENT_CATEGORIES = [
+  { value: 'produce', label: 'Produce' },
+  { value: 'dairy', label: 'Dairy & Eggs' },
+  { value: 'protein', label: 'Meat & Seafood' },
+  { value: 'grains', label: 'Bakery & Grains' },
+  { value: 'pantry', label: 'Pantry' },
+  { value: 'frozen', label: 'Frozen' },
+  { value: 'beverages', label: 'Beverages' },
+  { value: 'snacks', label: 'Snacks' },
+  { value: 'spices', label: 'Spices & Seasonings' },
+  { value: 'other', label: 'Other' },
 ];
 
-const LOCATIONS = ['Pantry', 'Refrigerator', 'Freezer', 'Cabinet'];
+const LOCATIONS: Array<{ value: PantryItem['location']; label: string }> = [
+  { value: 'pantry', label: 'Pantry' },
+  { value: 'fridge', label: 'Refrigerator' },
+  { value: 'freezer', label: 'Freezer' },
+];
+
+const locationLabel = (location: string): string =>
+  LOCATIONS.find((l) => l.value === location)?.label || location;
+
+interface PantryFormData {
+  ingredientId: string;
+  ingredientName: string;
+  ingredientCategory: string;
+  quantity: number;
+  unit: string;
+  location: PantryItem['location'];
+  expirationDate: string;
+}
+
+const emptyFormData: PantryFormData = {
+  ingredientId: '',
+  ingredientName: '',
+  ingredientCategory: 'other',
+  quantity: 1,
+  unit: 'pieces',
+  location: 'pantry',
+  expirationDate: '',
+};
 
 const Pantry: React.FC = () => {
+  const dispatch = useAppDispatch();
+  const { items, lowStockItems, expiringItems, loading, error } = useAppSelector(
+    (state) => state.pantry
+  );
+
   const [activeTab, setActiveTab] = useState(0);
-  const [items, setItems] = useState<PantryItem[]>([
-    {
-      id: '1',
-      name: 'Rice',
-      quantity: 5,
-      unit: 'lbs',
-      category: 'Grains & Pasta',
-      location: 'Pantry',
-      minQuantity: 2,
-    },
-    {
-      id: '2',
-      name: 'Olive Oil',
-      quantity: 1,
-      unit: 'bottle',
-      category: 'Oils & Condiments',
-      location: 'Pantry',
-      expirationDate: '2026-12-31',
-      minQuantity: 1,
-    },
-    {
-      id: '3',
-      name: 'Flour',
-      quantity: 0.5,
-      unit: 'lbs',
-      category: 'Baking',
-      location: 'Pantry',
-      minQuantity: 2,
-    },
-  ]);
+  const [availableIngredients, setAvailableIngredients] = useState<IngredientOption[]>([]);
 
   const [openDialog, setOpenDialog] = useState(false);
   const [editingItem, setEditingItem] = useState<PantryItem | null>(null);
-  const [formData, setFormData] = useState({
-    name: '',
-    quantity: 1,
-    unit: 'pieces',
-    category: 'Other',
-    location: 'Pantry',
-    expirationDate: '',
-    minQuantity: 0,
-  });
+  const [formData, setFormData] = useState<PantryFormData>(emptyFormData);
+  const [formError, setFormError] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  // Load real pantry data on mount — same thunks that drive the nav badge in Layout.tsx,
+  // so the page and the badge always reflect the same backend truth.
+  useEffect(() => {
+    dispatch(fetchPantryItems({}));
+    dispatch(fetchLowStockItems());
+    dispatch(fetchExpiringItems());
+  }, [dispatch]);
+
+  useEffect(() => {
+    const loadIngredients = async () => {
+      try {
+        const response = await ingredientAPI.getAll();
+        const data = Array.isArray(response.data) ? response.data : response.data?.data || [];
+        setAvailableIngredients(data);
+      } catch {
+        setAvailableIngredients([]);
+      }
+    };
+    loadIngredients();
+  }, []);
 
   const handleOpenDialog = (item?: PantryItem) => {
+    setFormError('');
     if (item) {
       setEditingItem(item);
       setFormData({
-        name: item.name,
+        ingredientId: item.ingredientId,
+        ingredientName: item.ingredient?.name || '',
+        ingredientCategory: item.ingredient?.category || 'other',
         quantity: item.quantity,
         unit: item.unit,
-        category: item.category,
         location: item.location,
-        expirationDate: item.expirationDate || '',
-        minQuantity: item.minQuantity,
+        expirationDate: item.expirationDate ? item.expirationDate.slice(0, 10) : '',
       });
     } else {
       setEditingItem(null);
-      setFormData({
-        name: '',
-        quantity: 1,
-        unit: 'pieces',
-        category: 'Other',
-        location: 'Pantry',
-        expirationDate: '',
-        minQuantity: 0,
-      });
+      setFormData(emptyFormData);
     }
     setOpenDialog(true);
   };
 
-  const handleSaveItem = () => {
-    if (editingItem) {
-      setItems(items.map(item =>
-        item.id === editingItem.id
-          ? { ...item, ...formData }
-          : item
-      ));
-    } else {
-      const newItem: PantryItem = {
-        id: Date.now().toString(),
-        ...formData,
-      };
-      setItems([...items, newItem]);
-    }
+  const handleCloseDialog = () => {
     setOpenDialog(false);
+    setFormError('');
   };
 
-  const handleDeleteItem = (id: string) => {
-    setItems(items.filter(item => item.id !== id));
+  const handleSaveItem = async () => {
+    const name = formData.ingredientName.trim();
+    if (!name) {
+      setFormError('Please enter an ingredient name');
+      return;
+    }
+    if (!formData.quantity || formData.quantity <= 0) {
+      setFormError('Please enter a valid quantity greater than 0');
+      return;
+    }
+    if (!formData.unit.trim()) {
+      setFormError('Please enter a unit (e.g., lbs, bottle, pieces)');
+      return;
+    }
+
+    setSaving(true);
+    setFormError('');
+
+    try {
+      if (editingItem) {
+        // The backend update endpoint only accepts quantity/unit/location/expirationDate —
+        // the ingredient identity of an existing pantry entry isn't changeable.
+        await dispatch(
+          updatePantryItem({
+            id: editingItem.id,
+            data: {
+              quantity: Number(formData.quantity),
+              unit: formData.unit.trim(),
+              location: formData.location,
+              expirationDate: formData.expirationDate || null,
+            },
+          })
+        ).unwrap();
+      } else {
+        let ingredientId = formData.ingredientId;
+
+        if (!ingredientId) {
+          const existing = availableIngredients.find(
+            (ing) => ing.name.toLowerCase() === name.toLowerCase()
+          );
+          if (existing) {
+            ingredientId = existing.id;
+          } else {
+            const created = await ingredientAPI.create({
+              name,
+              category: formData.ingredientCategory,
+              unit: formData.unit.trim(),
+              averagePrice: 0,
+            });
+            const createdIngredient = (created.data?.data || created.data) as IngredientOption;
+            ingredientId = createdIngredient.id;
+            setAvailableIngredients((prev) => [...prev, createdIngredient]);
+          }
+        }
+
+        await dispatch(
+          addPantryItem({
+            ingredientId,
+            quantity: Number(formData.quantity),
+            unit: formData.unit.trim(),
+            location: formData.location,
+            expirationDate: formData.expirationDate || undefined,
+          })
+        ).unwrap();
+      }
+
+      // Adding/editing an item can move it in or out of the low-stock / expiring-soon
+      // buckets, so refresh those the same way Layout.tsx does for the nav badge.
+      dispatch(fetchLowStockItems());
+      dispatch(fetchExpiringItems());
+
+      setOpenDialog(false);
+    } catch (err: unknown) {
+      setFormError(
+        typeof err === 'string' ? err : getApiErrorMessage(err, 'Failed to save pantry item')
+      );
+    } finally {
+      setSaving(false);
+    }
   };
 
-  const lowStockItems = items.filter(item => item.quantity <= item.minQuantity);
-  const expiringItems = items.filter(item => {
-    if (!item.expirationDate) return false;
-    const daysUntilExpiry = Math.floor(
-      (new Date(item.expirationDate).getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24)
-    );
-    return daysUntilExpiry <= 7 && daysUntilExpiry >= 0;
-  });
+  const handleDeleteItem = async (id: string) => {
+    try {
+      await dispatch(deletePantryItem(id)).unwrap();
+    } catch {
+      // Failure surfaces via the redux `error` state below.
+    }
+  };
 
-  const getFilteredItems = () => {
+  const getFilteredItems = (): PantryItem[] => {
     switch (activeTab) {
       case 1:
         return lowStockItems;
@@ -177,6 +266,17 @@ const Pantry: React.FC = () => {
   };
 
   const filteredItems = getFilteredItems();
+  const initialLoading = loading && items.length === 0;
+
+  if (initialLoading) {
+    return (
+      <Container maxWidth="lg">
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '400px' }}>
+          <CircularProgress />
+        </Box>
+      </Container>
+    );
+  }
 
   return (
     <Container maxWidth="lg">
@@ -195,6 +295,12 @@ const Pantry: React.FC = () => {
             Add Item
           </Button>
         </Box>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => dispatch(clearError())}>
+            {error}
+          </Alert>
+        )}
 
         {/* Alerts */}
         {lowStockItems.length > 0 && (
@@ -245,13 +351,14 @@ const Pantry: React.FC = () => {
           (<Card>
             <List>
               {filteredItems.map((item, index) => {
-                const isLowStock = item.quantity <= item.minQuantity;
+                const isLowStock = lowStockItems.some((i) => i.id === item.id);
+                const isExpiringSoon = expiringItems.some((i) => i.id === item.id);
                 const daysUntilExpiry = item.expirationDate
                   ? Math.floor(
                       (new Date(item.expirationDate).getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24)
                     )
                   : null;
-                const isExpiringSoon = daysUntilExpiry !== null && daysUntilExpiry <= 7 && daysUntilExpiry >= 0;
+                const itemName = item.ingredient?.name || 'Unknown item';
 
                 return (
                   <React.Fragment key={item.id}>
@@ -260,14 +367,14 @@ const Pantry: React.FC = () => {
                         <Stack direction="row" spacing={1}>
                           <IconButton
                             edge="end"
-                            aria-label={`Edit ${item.name}`}
+                            aria-label={`Edit ${itemName}`}
                             onClick={() => handleOpenDialog(item)}
                           >
                             <EditIcon />
                           </IconButton>
                           <IconButton
                             edge="end"
-                            aria-label={`Delete ${item.name}`}
+                            aria-label={`Delete ${itemName}`}
                             onClick={() => handleDeleteItem(item.id)}
                           >
                             <DeleteIcon />
@@ -278,13 +385,17 @@ const Pantry: React.FC = () => {
                       <ListItemText
                         primary={
                           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                            <Typography variant="subtitle1">{item.name}</Typography>
+                            <Typography variant="subtitle1">{itemName}</Typography>
                             {isLowStock && (
                               <Chip label="Low Stock" size="small" color="warning" />
                             )}
                             {isExpiringSoon && (
                               <Chip
-                                label={`Expires in ${daysUntilExpiry} days`}
+                                label={
+                                  daysUntilExpiry !== null && daysUntilExpiry >= 0
+                                    ? `Expires in ${daysUntilExpiry} days`
+                                    : 'Expiring soon'
+                                }
                                 size="small"
                                 color="error"
                               />
@@ -297,11 +408,13 @@ const Pantry: React.FC = () => {
                               Quantity: {item.quantity} {item.unit}
                             </Typography>
                             <Typography variant="body2" color="text.secondary" component="span">
-                              Location: {item.location}
+                              Location: {locationLabel(item.location)}
                             </Typography>
-                            <Typography variant="body2" color="text.secondary" component="span">
-                              Category: {item.category}
-                            </Typography>
+                            {item.ingredient?.category && (
+                              <Typography variant="body2" color="text.secondary" component="span">
+                                Category: {item.ingredient.category}
+                              </Typography>
+                            )}
                           </Stack>
                         }
                       />
@@ -315,16 +428,45 @@ const Pantry: React.FC = () => {
         )}
       </Box>
       {/* Add/Edit Item Dialog */}
-      <Dialog open={openDialog} onClose={() => setOpenDialog(false)} maxWidth="sm" fullWidth>
+      <Dialog open={openDialog} onClose={handleCloseDialog} maxWidth="sm" fullWidth>
         <DialogTitle>{editingItem ? 'Edit Item' : 'Add Pantry Item'}</DialogTitle>
         <DialogContent>
           <Stack spacing={2} sx={{ mt: 1 }}>
-            <TextField
-              label="Item Name"
-              fullWidth
-              value={formData.name}
-              onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-              autoFocus
+            {formError && <Alert severity="error">{formError}</Alert>}
+            <Autocomplete
+              freeSolo
+              disabled={!!editingItem}
+              options={availableIngredients}
+              getOptionLabel={(option) => (typeof option === 'string' ? option : option.name)}
+              value={formData.ingredientName || null}
+              onChange={(_, value) => {
+                if (typeof value === 'string') {
+                  setFormData({ ...formData, ingredientId: '', ingredientName: value });
+                } else if (value) {
+                  setFormData({
+                    ...formData,
+                    ingredientId: value.id,
+                    ingredientName: value.name,
+                    ingredientCategory: value.category || formData.ingredientCategory,
+                  });
+                } else {
+                  setFormData({ ...formData, ingredientId: '', ingredientName: '' });
+                }
+              }}
+              onInputChange={(_, value) => {
+                if (value !== undefined) {
+                  setFormData((prev) => ({ ...prev, ingredientName: value }));
+                }
+              }}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Item Name"
+                  placeholder="Search or type new ingredient..."
+                  helperText="Select an existing ingredient or type a new one"
+                  autoFocus
+                />
+              )}
             />
             <Box sx={{ display: 'flex', gap: 2 }}>
               <TextField
@@ -333,6 +475,7 @@ const Pantry: React.FC = () => {
                 value={formData.quantity}
                 onChange={(e) => setFormData({ ...formData, quantity: Number(e.target.value) })}
                 sx={{ flex: 1 }}
+                slotProps={{ htmlInput: { min: 0, step: 0.25 } }}
               />
               <TextField
                 label="Unit"
@@ -341,37 +484,35 @@ const Pantry: React.FC = () => {
                 sx={{ flex: 1 }}
               />
             </Box>
-            <FormControl fullWidth>
-              <InputLabel>Category</InputLabel>
-              <Select
-                value={formData.category}
-                label="Category"
-                onChange={(e) => setFormData({ ...formData, category: e.target.value })}
-              >
-                {CATEGORIES.map(cat => (
-                  <MenuItem key={cat} value={cat}>{cat}</MenuItem>
-                ))}
-              </Select>
-            </FormControl>
+            {!editingItem && (
+              <FormControl fullWidth>
+                <InputLabel>Category</InputLabel>
+                <Select
+                  value={formData.ingredientCategory}
+                  label="Category"
+                  onChange={(e) => setFormData({ ...formData, ingredientCategory: e.target.value })}
+                  disabled={!!formData.ingredientId}
+                >
+                  {INGREDIENT_CATEGORIES.map((cat) => (
+                    <MenuItem key={cat.value} value={cat.value}>{cat.label}</MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
             <FormControl fullWidth>
               <InputLabel>Location</InputLabel>
               <Select
                 value={formData.location}
                 label="Location"
-                onChange={(e) => setFormData({ ...formData, location: e.target.value })}
+                onChange={(e) =>
+                  setFormData({ ...formData, location: e.target.value as PantryItem['location'] })
+                }
               >
-                {LOCATIONS.map(loc => (
-                  <MenuItem key={loc} value={loc}>{loc}</MenuItem>
+                {LOCATIONS.map((loc) => (
+                  <MenuItem key={loc.value} value={loc.value}>{loc.label}</MenuItem>
                 ))}
               </Select>
             </FormControl>
-            <TextField
-              label="Minimum Quantity (for alerts)"
-              type="number"
-              fullWidth
-              value={formData.minQuantity}
-              onChange={(e) => setFormData({ ...formData, minQuantity: Number(e.target.value) })}
-            />
             <TextField
               label="Expiration Date"
               type="date"
@@ -383,13 +524,13 @@ const Pantry: React.FC = () => {
           </Stack>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setOpenDialog(false)}>Cancel</Button>
+          <Button onClick={handleCloseDialog}>Cancel</Button>
           <Button
             onClick={handleSaveItem}
             variant="contained"
-            disabled={!formData.name}
+            disabled={!formData.ingredientName.trim() || saving}
           >
-            {editingItem ? 'Save Changes' : 'Add Item'}
+            {saving ? <CircularProgress size={20} /> : editingItem ? 'Save Changes' : 'Add Item'}
           </Button>
         </DialogActions>
       </Dialog>


### PR DESCRIPTION
## Summary

`Pantry.tsx` seeded its item list from three hardcoded `useState` mock objects (Rice, Olive Oil "Low Stock", Flour "Low Stock"). Add/Edit/Delete only mutated component state, so nothing persisted across a refresh, and the page's contents contradicted the real nav badge — `Layout.tsx`/`MobileBottomNav.tsx` already drive the Pantry badge from real backend state via `pantrySlice`'s `fetchExpiringItems`/`fetchLowStockItems`.

## Backend: nothing needed, already existed

Investigated `backend/src/routes/pantry.routes.ts` and `pantry.controller.ts` before touching anything — full CRUD already existed:

- `GET /api/pantry` (list), `GET /api/pantry/:id`
- `POST /api/pantry` (create), `PUT /api/pantry/:id` (update), `DELETE /api/pantry/:id`
- `GET /api/pantry/low-stock`, `GET /api/pantry/expiring-soon`, `POST /api/pantry/:id/consume`

`pantrySlice.ts` also already had matching `createAsyncThunk`s for all of the above (`fetchPantryItems`, `fetchPantryItemById`, `fetchLowStockItems`, `fetchExpiringItems`, `addPantryItem`, `updatePantryItem`, `deletePantryItem`). So this ended up being a **frontend-only wiring fix** — no backend routes/controllers/validation were added or changed.

## Frontend changes

Rewrote `frontend/src/pages/Pantry.tsx`:

- Removed the hardcoded mock `useState` seed entirely.
- Dispatches `fetchPantryItems`, `fetchLowStockItems`, `fetchExpiringItems` on mount — the exact same thunks `Layout.tsx` uses for the nav badge — so the "All Items" / "Low Stock" / "Expiring Soon" tabs and the badge now read off the *same* Redux state and can't disagree.
- Add/Edit/Delete dispatch `addPantryItem` / `updatePantryItem` / `deletePantryItem` (with `.unwrap()` + try/catch, matching the pattern in `RecipeDetail.tsx`'s `handleConfirmDelete`), so changes now persist to the backend and survive a refresh.
- Since `PantryInventory` rows reference an `Ingredient` (not a free-text name), adding an item resolves an existing ingredient or creates a new one via `ingredientAPI`, mirroring the ingredient-autocomplete pattern already used in `CreateRecipe.tsx` (freeSolo `Autocomplete`, `onChange`/`onInputChange` split).
- Editing an existing item disables the ingredient field, since the backend's `PUT /api/pantry/:id` only accepts `quantity`/`unit`/`location`/`expirationDate` — it doesn't support changing which ingredient a pantry row points to.
- Location select now matches the actual `PantryLocation` Prisma enum (`pantry`/`fridge`/`freezer`) instead of the mock's invented `"Cabinet"` option.
- Per-item "Low Stock" / "Expiring soon" chips are now derived from membership in the real `lowStockItems`/`expiringItems` arrays instead of a re-implemented client-side threshold, so the visual badges can't drift from the backend's definition of low-stock (`quantity <= 1`, hardcoded server-side per an existing code comment in `pantry.controller.ts`).

## Validation

- `npm run lint` — 0 errors in `frontend/` (same 7 pre-existing `react-hooks/exhaustive-deps` warnings in unrelated files; nothing from `Pantry.tsx`).
- `npm run build` — passes (`tsc -b && vite build`).
- Backend untouched, so no backend build/lint run was needed.
- **Live browser QA**: partially completed, not finished end-to-end. I did confirm, against a running local dev stack (real Postgres with seeded pantry fixtures for `test@example.com`) logged in via the classic login form, that the Pantry page now renders real backend rows (`Rice`, `Olive Oil`, `Salt` — correctly *not* the mock's `Flour`) with tab counts (`All Items (3)`, `Low Stock (2)`) matching the actual low-stock computation, and the nav badge dot lit up consistent with that same data. I was not able to finish exercising Add/Edit/Delete end-to-end (including persistence across a real reload) in the browser before hitting the auth rate limiter repeatedly in this sandbox environment (its 1-minute test-mode window kept re-triggering across script iterations). Given that constraint, I relied on `npm run build`/`npm run lint` plus a careful manual read-through of the final `Pantry.tsx` (verifying the dispatch/`.unwrap()` pattern matches `RecipeDetail.tsx`, and that the payload shapes match `pantry.controller.ts`'s accepted fields) to gain confidence in the Add/Edit/Delete paths. Recommend a manual smoke test (or a Playwright run outside this sandbox) of Add → refresh → Edit → refresh → Delete → refresh before merging.

Fixes #302

## Test plan

- [x] `npm run lint` (frontend) — clean
- [x] `npm run build` (frontend) — clean
- [x] Manual check: Pantry page renders real backend data (not mock), tab counts match real low-stock/expiring-soon data, nav badge reflects same state
- [ ] Manual check: Add → refresh → item persists
- [ ] Manual check: Edit (e.g. drop quantity to trigger low-stock) → refresh → change persists, Low Stock tab updates
- [ ] Manual check: Delete → refresh → item gone, nav badge count updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)