### PR TITLE
fix(test): update MemberWelcome mock for familyName/displayName rename

### DIFF
--- a/frontend/src/__tests__/pages/MemberWelcome.test.tsx
+++ b/frontend/src/__tests__/pages/MemberWelcome.test.tsx
@@ -26,7 +26,7 @@ function createStore(authState = {}) {
     } as any,
     preloadedState: {
       auth: {
-        user: { id: 'user-1', email: 'a@b.com', name: 'Tracy', role: 'user' },
+        user: { id: 'user-1', email: 'a@b.com', familyName: 'Smith', displayName: 'Tracy', role: 'user' },
         isAuthenticated: true,
         loading: false,
         error: null,


### PR DESCRIPTION
## Summary
- CI on `main` has been red since PR #320 merged: `MemberWelcome.test.tsx` mocked `user.name`, a field that no longer exists after `User.name` was split into `familyName` (household) + `displayName` (per-member).
- `getDisplayName()` correctly fell back to `'there'`, failing 3 assertions expecting `Hey, Tracy!`.
- Updated the mock to set `familyName`/`displayName` to match how `LocalLogin.tsx` populates them in production.

## Test plan
- [x] `npx vitest run src/__tests__/pages/MemberWelcome.test.tsx` — 11/11 pass
- [x] `npx vitest run` (full frontend suite) — 127/127 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)