### PR TITLE
fix(docker): copy prisma.config.ts into the production image — fixes prod backend crash-loop

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -118,6 +118,12 @@ COPY --from=backend-builder /app/dist ./dist
 # Prisma schema — needed for `prisma migrate deploy` at container startup
 COPY --from=backend-builder /app/prisma ./prisma
 
+# Prisma 7 reads the datasource URL and migration adapter exclusively from
+# this config file (no more `env("DATABASE_URL")` in schema.prisma for CLI
+# commands) — without it, `prisma migrate deploy` fails at container startup
+# with "the datasource.url property is required", crash-looping the container.
+COPY --from=backend-builder /app/prisma.config.ts ./prisma.config.ts
+
 # Regenerate the Prisma client natively for arm64.
 # pnpm prune --prod in stage 2 wipes .prisma/client (a side effect of the prisma
 # devDep), so we re-run generate here on the actual target platform. The prisma


### PR DESCRIPTION
## Summary

**Production is currently down.** The `meals-backend` container on pi4 is crash-looping: every start runs `docker-entrypoint.sh`, secrets load fine, then `prisma migrate deploy` fails with:

```
Error: The datasource.url property is required in your Prisma config file when using prisma migrate deploy.
```

Confirmed live via `podman ps -a` on pi4 (backend `unhealthy`, restarting every few seconds) and by running a throwaway container off the deployed image — `prisma.config.ts` is not present in `/app` at all.

## Root cause

The Prisma 7 migration (#269) made `prisma.config.ts` the sole source of the datasource URL and migration adapter for Prisma CLI commands (the old `env("DATABASE_URL")` in `schema.prisma` no longer works for this). But `backend/Dockerfile`'s production stage only ever copied `prisma/` and `dist/` from the builder — `prisma.config.ts` (which lives at the backend root, not inside `prisma/`) was never added to the production image's `COPY` list. So `prisma migrate deploy` has no way to get a connection string, fails immediately, and the container never reaches `exec node dist/index.js`.

## Fix

One line: copy `prisma.config.ts` alongside `prisma/` and `dist/` in the production stage.

## Test plan

- [x] Confirmed the missing file by inspecting the currently-deployed image directly
- [ ] CI build passes
- [ ] Pull the rebuilt image to pi4 (`pi-deploy-registry.sh`) and confirm `meals-backend` reaches `healthy` and stays up
- [ ] Confirm `/health`, `/api/*`, and `/` all respond from `http://192.168.4.110/`

Note: all in-flight CI runs were cancelled before this push so the fix builds clean rather than racing stale runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)