### PR TITLE
fix(docker): backend-builder fails on prisma postinstall/prune lifecycle scripts

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -74,6 +74,13 @@ COPY backend/package.json backend/pnpm-lock.yaml backend/pnpm-workspace.yaml ./
 # release with different build-script enforcement behavior (see #290).
 RUN npm install -g pnpm@11.1.2 --quiet
 
+# package.json's postinstall runs `prisma generate`, which needs the schema
+# and config present *before* `pnpm install` executes it — copy them ahead
+# of the install step or postinstall fails with "schema.prisma: file not
+# found" even though both files exist later in the build context.
+COPY backend/prisma ./prisma
+COPY backend/prisma.config.ts ./prisma.config.ts
+
 RUN pnpm install --no-frozen-lockfile
 
 COPY backend .
@@ -84,9 +91,14 @@ ENV PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1
 ENV DATABASE_URL="postgresql://dummy:dummy@localhost:5432/dummy"
 
 # Generate Prisma client, compile TypeScript, strip devDeps.
+# --ignore-scripts on prune: pruning removes the `prisma` devDependency
+# itself, and pnpm re-fires the root package.json's postinstall
+# (`prisma generate`) as part of that lifecycle — failing with "prisma:
+# not found" since the binary was just pruned. The client is already
+# generated above, so lifecycle scripts aren't needed here.
 RUN pnpm prisma generate && \
     pnpm build && \
-    pnpm prune --prod && \
+    pnpm prune --prod --ignore-scripts && \
     pnpm store prune && \
     rm -rf /root/.local/share/pnpm/store /tmp/* /root/.cache /root/.npm
 


### PR DESCRIPTION
## Summary
Following #330, the backend Docker build was still failing in CI at the `backend-builder` stage — different root cause, same failure signature (`pnpm install` exiting 1 with a Prisma error). Two chained bugs, both from pnpm lifecycle scripts firing before/after the files or binaries they need:

1. `package.json`'s `postinstall: prisma generate` fires during `pnpm install` (line ~77), but `prisma/schema.prisma` and `prisma.config.ts` weren't copied into the build context until the later `COPY backend .` — failing with `schema.prisma: file not found`. Fix: copy those two paths ahead of `pnpm install`.
2. With that fixed, a second failure surfaced: `pnpm prune --prod` removes the `prisma` devDependency, and pnpm re-fires the same postinstall script as part of pruning — now failing with `prisma: not found` since the binary was just removed. Fix: add `--ignore-scripts` to the prune call (the client is already generated by the explicit `pnpm prisma generate` earlier in the same `RUN`).

## Test plan
- [x] `podman build --platform linux/amd64 --target backend-builder -f backend/Dockerfile .` — completes successfully (previously failed at `pnpm install`)
- [ ] Full multi-stage `linux/arm64` build (in progress locally, QEMU is slow — will confirm before merge if needed)
- [ ] CI's "Build and Push Container Images" workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)