### PR TITLE
fix(prisma): seed scripts still can't connect — dotenv never loaded

### DIFF
--- a/backend/analyze-feedback-logs.js
+++ b/backend/analyze-feedback-logs.js
@@ -3,6 +3,7 @@
  * Generates insights for GitHub issue creation
  */
 
+require('dotenv/config');
 const { PrismaClient } = require('@prisma/client');
 const { PrismaPg } = require('@prisma/adapter-pg');
 const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });

--- a/backend/prisma/seed-visual-login.ts
+++ b/backend/prisma/seed-visual-login.ts
@@ -13,6 +13,7 @@
  * Idempotent: skips recipes and images that already exist.
  */
 
+import 'dotenv/config';
 import { PrismaClient, Difficulty, MealType, RecipeSource } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 import axios from 'axios';

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -3,6 +3,7 @@
  * All rights reserved.
  */
 
+import 'dotenv/config';
 import { PrismaClient } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 import bcrypt from 'bcryptjs';

--- a/backend/seed-recipes.ts
+++ b/backend/seed-recipes.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { PrismaClient, Difficulty, MealType } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 


### PR DESCRIPTION
## Summary
- `seed.ts`, `seed-visual-login.ts`, `seed-recipes.ts`, and `analyze-feedback-logs.js` are invoked directly via `ts-node`/`node`, bypassing `index.ts`'s `dotenv.config()` call
- `DATABASE_URL` was therefore `undefined` when `PrismaPg`'s adapter was constructed, surfacing as `SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a string` instead of a clear connection error
- Adds `import 'dotenv/config'` (or `require('dotenv/config')`) as the first line of each file

Fixes #322

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec eslint` clean on changed files
- [x] Verified with a throwaway `.env` pointing at an unreachable host: before the fix, all four scripts failed with the SASL/garbage-connection-string error; after the fix, they fail with `ECONNREFUSED`/`P1001 Can't reach database server`, confirming `DATABASE_URL` is now loaded correctly
- [ ] Full seed run against a real local Postgres (not available in this sandbox)