### PR TITLE
fix(frontend): hard reload no longer bounces authenticated users to /login

### DIFF
--- a/frontend/e2e/fixtures/auth.fixture.ts
+++ b/frontend/e2e/fixtures/auth.fixture.ts
@@ -57,6 +57,9 @@ export const test = base.extend<AuthFixtures>({
       await authenticatePage(page, backendURL);
     }
     await page.goto('/dashboard');
+    // PrivateRoute shows a spinner until bootstrapAuth() resolves (#321) —
+    // wait it out so callers don't assert against the pre-content state.
+    await page.getByRole('progressbar').waitFor({ state: 'hidden' });
     await use(page);
   },
 });

--- a/frontend/e2e/tests/ftue/ftue-audit.spec.ts
+++ b/frontend/e2e/tests/ftue/ftue-audit.spec.ts
@@ -219,6 +219,9 @@ test.describe('Dashboard (/dashboard)', () => {
     }
 
     await page.goto('/dashboard');
+    // PrivateRoute shows a spinner until bootstrapAuth() resolves (#321) —
+    // networkidle alone doesn't guarantee that repaint has happened.
+    await page.getByRole('progressbar').waitFor({ state: 'hidden' });
     await page.waitForLoadState('networkidle');
   });
 

--- a/frontend/src/__tests__/store/authSlice.test.ts
+++ b/frontend/src/__tests__/store/authSlice.test.ts
@@ -21,7 +21,9 @@ const mockUser: User = {
 const initialState = {
   user: null,
   isAuthenticated: false,
-  loading: false,
+  // Starts true — PrivateRoute waits for bootstrapAuth() to resolve before
+  // redirecting, instead of racing ahead on the pre-effect default (#321).
+  loading: true,
   error: null,
 };
 

--- a/frontend/src/store/slices/authSlice.ts
+++ b/frontend/src/store/slices/authSlice.ts
@@ -46,7 +46,10 @@ interface AuthState {
 const initialState: AuthState = {
   user: null,
   isAuthenticated: false,
-  loading: false,
+  // Starts true so PrivateRoute shows its spinner until the initial
+  // bootstrapAuth() (dispatched on mount by AuthContext) resolves, instead
+  // of racing ahead on this pre-effect default and redirecting to /login.
+  loading: true,
   error: null,
 };
 


### PR DESCRIPTION
## Summary
- `authSlice`'s `initialState.loading` was `false`, so `PrivateRoute`'s very first synchronous render (before `AuthContext`'s `useEffect` dispatches `bootstrapAuth()`) saw `{isAuthenticated: false, loading: false}` and immediately fired `<Navigate to="/login" replace />`
- `bootstrapAuth()` then resolves correctly a moment later, but the URL has already been replaced to `/login` with nothing to route the user back
- Fix: default `loading` to `true` so `PrivateRoute` shows its existing spinner until the initial `bootstrapAuth()` call resolves, matching the pattern the issue's author already traced through the code

Fixes #321

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec eslint src/store/slices/authSlice.ts` clean
- [x] Confirmed `logout.fulfilled` explicitly sets `loading = false` (doesn't rely on `initialState`), so this doesn't regress logout
- [ ] Manual verification (hard reload on a protected route while authenticated) — no local Postgres available in this sandbox to run the full app; recommend a quick manual check or the existing Playwright suite before merge