### PR TITLE
fix(frontend): hardcoded light-mode overlays break dark mode in FeedbackDialog and LocalLogin

### DIFF
--- a/frontend/src/components/FeedbackDialog.tsx
+++ b/frontend/src/components/FeedbackDialog.tsx
@@ -33,6 +33,7 @@ import {
   CameraAlt as CameraIcon,
 } from '@mui/icons-material';
 import { useLocation } from 'react-router-dom';
+import { useTheme } from '@mui/material/styles';
 import type { Options as Html2CanvasOptions } from 'html2canvas';
 import api from '../services/api';
 import { isAxiosError } from 'axios';
@@ -58,6 +59,7 @@ interface RateLimitInfo {
 }
 
 const FeedbackDialog: React.FC<FeedbackDialogProps> = ({ open, onClose, onSuccess }) => {
+  const theme = useTheme();
   const location = useLocation();
   const isLandscape = useMediaQuery('(orientation: landscape) and (max-height: 500px)');
   const isIOS = /iPhone|iPad|iPod/i.test(navigator.userAgent);
@@ -120,7 +122,7 @@ const FeedbackDialog: React.FC<FeedbackDialogProps> = ({ open, onClose, onSucces
         allowTaint: true,
         useCORS: true,
         logging: false,
-        backgroundColor: '#ffffff',
+        backgroundColor: theme.palette.background.default,
         scale: 1,
       });
       const dataUrl = canvas.toDataURL('image/png');

--- a/frontend/src/pages/LocalLogin.tsx
+++ b/frontend/src/pages/LocalLogin.tsx
@@ -26,7 +26,7 @@ import { ArrowBack as ArrowBackIcon } from '@mui/icons-material';
 import { useAppDispatch } from '../store/hooks';
 import { setCredentials } from '../store/slices/authSlice';
 import api, { visualAuthAPI } from '../services/api';
-import { useTheme } from '@mui/material/styles';
+import { useTheme, alpha } from '@mui/material/styles';
 
 interface UserEntry {
   id: string;
@@ -234,7 +234,7 @@ const LocalLogin: React.FC = () => {
                     display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'center',
-                    bgcolor: 'rgba(255,255,255,0.7)',
+                    bgcolor: alpha(theme.palette.background.paper, 0.7),
                     zIndex: 1,
                     borderRadius: 2,
                   }}


### PR DESCRIPTION
## Summary
- `FeedbackDialog.tsx` forced `backgroundColor: '#ffffff'` in its `html2canvas` screenshot capture, so a dark-mode bug report screenshot rendered with a white background instead of the user's actual dark screen — now uses `theme.palette.background.default`, matching the token already used elsewhere in this file for the page background.
- `LocalLogin.tsx` used a hardcoded `rgba(255,255,255,0.7)` overlay while verifying a visual-login picture selection, flashing a bright white panel over the photo grid in dark mode — now uses `alpha(theme.palette.background.paper, 0.7)`.

Fixes #306

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec eslint` clean on both changed files (one pre-existing, unrelated warning on `LocalLogin.tsx` confirmed present on `main` too)
- [ ] Manual verification in dark mode (feedback screenshot capture + visual-login verification overlay) — no running dev server in this sandbox; recommend a quick manual check before merge