### PR TITLE
fix(frontend): standardize destructive-delete confirmation across the app

### DIFF
--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2026 e2kd7n
+ * All rights reserved.
+ */
+
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+} from '@mui/material';
+
+export interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  message: React.ReactNode;
+  confirmLabel?: string;
+  /** Shown on the confirm button while `loading` is true, e.g. "Deleting…". */
+  confirmingLabel?: string;
+  cancelLabel?: string;
+  confirmColor?: 'error' | 'primary' | 'warning';
+  loading?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Standard destructive-action confirmation dialog (see design principle:
+ * "Delete actions require confirmation to prevent accidental data loss").
+ * Pair with `useConfirmDialog` rather than managing open/message state ad hoc.
+ */
+const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
+  open,
+  title,
+  message,
+  confirmLabel = 'Delete',
+  confirmingLabel = 'Deleting…',
+  cancelLabel = 'Cancel',
+  confirmColor = 'error',
+  loading = false,
+  onConfirm,
+  onCancel,
+}) => (
+  <Dialog open={open} onClose={() => !loading && onCancel()} maxWidth="sm" fullWidth>
+    <DialogTitle>{title}</DialogTitle>
+    <DialogContent>
+      <DialogContentText component="div">{message}</DialogContentText>
+    </DialogContent>
+    <DialogActions>
+      <Button onClick={onCancel} disabled={loading}>
+        {cancelLabel}
+      </Button>
+      <Button onClick={onConfirm} variant="contained" color={confirmColor} disabled={loading}>
+        {loading ? confirmingLabel : confirmLabel}
+      </Button>
+    </DialogActions>
+  </Dialog>
+);
+
+export default ConfirmDialog;
+
+// Made with Bob

--- a/frontend/src/hooks/useConfirmDialog.ts
+++ b/frontend/src/hooks/useConfirmDialog.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2026 e2kd7n
+ * All rights reserved.
+ */
+
+import React, { useCallback, useRef, useState } from 'react';
+
+export interface ConfirmOptions {
+  title: string;
+  message: React.ReactNode;
+  confirmLabel?: string;
+  confirmingLabel?: string;
+  cancelLabel?: string;
+  confirmColor?: 'error' | 'primary' | 'warning';
+}
+
+interface ConfirmState extends ConfirmOptions {
+  open: boolean;
+}
+
+/**
+ * Promise-based destructive-action confirmation, pairing with `<ConfirmDialog />`:
+ *
+ *   const { confirm, confirmDialogProps } = useConfirmDialog();
+ *   const ok = await confirm({ title: 'Delete Item', message: `Delete "${name}"?` });
+ *   if (!ok) return;
+ *   ...
+ *   <ConfirmDialog {...confirmDialogProps} />
+ */
+export function useConfirmDialog() {
+  const [state, setState] = useState<ConfirmState | null>(null);
+  const resolverRef = useRef<((confirmed: boolean) => void) | null>(null);
+
+  const confirm = useCallback((options: ConfirmOptions) => {
+    setState({ ...options, open: true });
+    return new Promise<boolean>((resolve) => {
+      resolverRef.current = resolve;
+    });
+  }, []);
+
+  const close = useCallback((confirmed: boolean) => {
+    resolverRef.current?.(confirmed);
+    resolverRef.current = null;
+    setState((s) => (s ? { ...s, open: false } : s));
+  }, []);
+
+  const handleConfirm = useCallback(() => close(true), [close]);
+  const handleCancel = useCallback(() => close(false), [close]);
+
+  return {
+    confirm,
+    confirmDialogProps: {
+      open: state?.open ?? false,
+      title: state?.title ?? '',
+      message: state?.message ?? '',
+      confirmLabel: state?.confirmLabel,
+      confirmingLabel: state?.confirmingLabel,
+      cancelLabel: state?.cancelLabel,
+      confirmColor: state?.confirmColor,
+      onConfirm: handleConfirm,
+      onCancel: handleCancel,
+    },
+  };
+}

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -52,6 +52,8 @@ import { useNavigate } from 'react-router-dom';
 import api from '../services/api';
 import { isAxiosError } from 'axios';
 import { getApiErrorMessage } from '../utils/errorHandler';
+import ConfirmDialog from '../components/ConfirmDialog';
+import { useConfirmDialog } from '../hooks/useConfirmDialog';
 
 interface AppSetting {
   key: string;
@@ -90,6 +92,7 @@ interface SystemStats {
 
 export default function AdminDashboard() {
   const navigate = useNavigate();
+  const { confirm, confirmDialogProps } = useConfirmDialog();
   const [activeTab, setActiveTab] = useState(0);
 
   // Users tab state
@@ -194,9 +197,11 @@ export default function AdminDashboard() {
   };
 
   const handleDeleteUser = async (userId: string) => {
-    if (!window.confirm('Are you sure you want to delete this user? This action cannot be undone.')) {
-      return;
-    }
+    const confirmed = await confirm({
+      title: 'Delete User',
+      message: 'Are you sure you want to delete this user? This action cannot be undone.',
+    });
+    if (!confirmed) return;
     try {
       await api.delete(`/admin/users/${userId}`);
       setSuccess('User deleted successfully');
@@ -779,6 +784,7 @@ export default function AdminDashboard() {
           </Dialog>
         </Box>
       )}
+      <ConfirmDialog {...confirmDialogProps} />
     </Container>
   );
 }

--- a/frontend/src/pages/GroceryList.tsx
+++ b/frontend/src/pages/GroceryList.tsx
@@ -48,6 +48,8 @@ import {
   Fastfood as SnacksIcon,
   Category as OtherIcon,
 } from '@mui/icons-material';
+import ConfirmDialog from '../components/ConfirmDialog';
+import { useConfirmDialog } from '../hooks/useConfirmDialog';
 
 interface Ingredient {
   id: string;
@@ -108,6 +110,7 @@ const mapIngredientCategoryToStore = (ingredientCategory: string): string => {
 };
 
 const GroceryList: React.FC = () => {
+  const { confirm, confirmDialogProps } = useConfirmDialog();
   const [, setGroceryLists] = useState<GroceryList[]>([]);
   const [currentList, setCurrentList] = useState<GroceryList | null>(null);
   const [loading, setLoading] = useState(true);
@@ -236,6 +239,13 @@ const GroceryList: React.FC = () => {
 
   const handleDeleteItem = async (itemId: string) => {
     if (!currentList) return;
+
+    const itemName = currentList.items.find((i) => i.id === itemId)?.ingredient?.name ?? 'this item';
+    const confirmed = await confirm({
+      title: 'Delete Grocery Item',
+      message: `Are you sure you want to delete "${itemName}"? This action cannot be undone.`,
+    });
+    if (!confirmed) return;
 
     try {
       const token = localStorage.getItem('accessToken');
@@ -566,6 +576,7 @@ const GroceryList: React.FC = () => {
           <Button onClick={() => setOpenDialog(false)}>Close</Button>
         </DialogActions>
       </Dialog>
+      <ConfirmDialog {...confirmDialogProps} />
     </Container>
   );
 };

--- a/frontend/src/pages/Pantry.tsx
+++ b/frontend/src/pages/Pantry.tsx
@@ -53,6 +53,8 @@ import {
 import type { PantryItem } from '../store/slices/pantrySlice';
 import { ingredientAPI } from '../services/api';
 import { getApiErrorMessage } from '../utils/errorHandler';
+import ConfirmDialog from '../components/ConfirmDialog';
+import { useConfirmDialog } from '../hooks/useConfirmDialog';
 
 interface IngredientOption {
   id: string;
@@ -105,6 +107,7 @@ const emptyFormData: PantryFormData = {
 };
 
 const Pantry: React.FC = () => {
+  const { confirm, confirmDialogProps } = useConfirmDialog();
   const dispatch = useAppDispatch();
   const { items, lowStockItems, expiringItems, loading, error } = useAppSelector(
     (state) => state.pantry
@@ -246,7 +249,13 @@ const Pantry: React.FC = () => {
     }
   };
 
-  const handleDeleteItem = async (id: string) => {
+  const handleDeleteItem = async (id: string, itemName: string) => {
+    const confirmed = await confirm({
+      title: 'Delete Pantry Item',
+      message: `Are you sure you want to delete "${itemName}"? This action cannot be undone.`,
+    });
+    if (!confirmed) return;
+
     try {
       await dispatch(deletePantryItem(id)).unwrap();
     } catch {
@@ -375,7 +384,7 @@ const Pantry: React.FC = () => {
                           <IconButton
                             edge="end"
                             aria-label={`Delete ${itemName}`}
-                            onClick={() => handleDeleteItem(item.id)}
+                            onClick={() => handleDeleteItem(item.id, itemName)}
                           >
                             <DeleteIcon />
                           </IconButton>
@@ -534,6 +543,7 @@ const Pantry: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
+      <ConfirmDialog {...confirmDialogProps} />
     </Container>
   );
 };

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -51,6 +51,8 @@ import { userAPI, familyMemberAPI, visualAuthAPI } from '../services/api';
 import { DIETARY_PREFERENCES, COMMON_ALLERGENS, getDietaryLabel } from '../constants/dietaryOptions';
 import { isAxiosError } from 'axios';
 import { getApiErrorMessage } from '../utils/errorHandler';
+import ConfirmDialog from '../components/ConfirmDialog';
+import { useConfirmDialog } from '../hooks/useConfirmDialog';
 
 interface TabPanelProps {
   children?: React.ReactNode;
@@ -107,6 +109,7 @@ const skillLevels = ['beginner', 'intermediate', 'advanced'];
 const ageGroups = ['child', 'teen', 'adult'];
 
 const Profile: React.FC = () => {
+  const { confirm, confirmDialogProps } = useConfirmDialog();
   const [tabValue, setTabValue] = useState(0);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -292,7 +295,11 @@ const Profile: React.FC = () => {
   };
 
   const handleDeleteMember = async (id: string) => {
-    if (!window.confirm('Are you sure you want to delete this family member?')) return;
+    const confirmed = await confirm({
+      title: 'Delete Family Member',
+      message: 'Are you sure you want to delete this family member? This action cannot be undone.',
+    });
+    if (!confirmed) return;
 
     try {
       await familyMemberAPI.delete(id);
@@ -850,6 +857,7 @@ const Profile: React.FC = () => {
           {snackbar.message}
         </Alert>
       </Snackbar>
+      <ConfirmDialog {...confirmDialogProps} />
     </Container>
   );
 };


### PR DESCRIPTION
## Summary
Delete confirmation was implemented four different ways:
1. `RecipeDetail.tsx` — a styled MUI `Dialog` (the best pattern in the app, used as the reference)
2. `Profile.tsx` and `AdminDashboard.tsx` — native `window.confirm()`, unstyled and ignoring the theme, with different wording each time
3. `Pantry.tsx` and `GroceryList.tsx` — **no confirmation at all**, single-click delete with no recovery path

This violates `docs/design/DESIGN_PRINCIPLES.md` Principle 1 (User CRUD Authority: "Delete actions require confirmation to prevent accidental data loss").

## Changes
- New `ConfirmDialog` component (`frontend/src/components/ConfirmDialog.tsx`) matching `RecipeDetail.tsx`'s existing dialog pattern
- New `useConfirmDialog` hook (`frontend/src/hooks/useConfirmDialog.ts`) exposing a promise-based `confirm({title, message})` API, to prevent this drifting again
- Wired into `Profile.tsx` (family member delete), `AdminDashboard.tsx` (user delete), `Pantry.tsx` (item delete), and `GroceryList.tsx` (item delete)
- `RecipeDetail.tsx` is left as-is — it's already the reference pattern the issue points to, not one of the four flows needing a fix

Fixes #304

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec eslint` clean on all changed files (two pre-existing, unrelated `exhaustive-deps` warnings confirmed present on `main` too)
- [x] `pnpm exec vite build` succeeds
- [ ] Manual verification of all four delete flows — no running dev server/DB in this sandbox; recommend a quick manual pass before merge