### PR TITLE
fix(frontend): update in place instead of duplicating on pantry item merge

### DIFF
--- a/frontend/src/store/slices/pantrySlice.ts
+++ b/frontend/src/store/slices/pantrySlice.ts
@@ -221,7 +221,12 @@ const pantrySlice = createSlice({
       })
       .addCase(addPantryItem.fulfilled, (state, action) => {
         state.loading = false;
-        state.items.unshift(action.payload);
+        const index = state.items.findIndex(item => item.id === action.payload.id);
+        if (index !== -1) {
+          state.items[index] = action.payload;
+        } else {
+          state.items.unshift(action.payload);
+        }
       })
       .addCase(addPantryItem.rejected, (state, action) => {
         state.loading = false;


### PR DESCRIPTION
## Summary
- `addPantryItem.fulfilled` unconditionally unshifted the API response into `state.items`, but the backend merges quantity into an existing row (same `ingredientId` + `unit`) and returns that row's id — causing a duplicate React-key entry in the UI until the next refetch.
- Now checks whether the id already exists and updates in place, matching the pattern already used in `updatePantryItem.fulfilled`.

Fixes #333

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Manually add a pantry item, then add another with the same ingredient+unit and confirm it updates the existing row instead of duplicating it