### PR TITLE
fix(backend): eliminate check-then-create race in getPreferences

### DIFF
--- a/backend/src/controllers/user.controller.ts
+++ b/backend/src/controllers/user.controller.ts
@@ -124,47 +124,29 @@ export async function getPreferences(
   try {
     const userId = getUserId(req);
 
-    let preferences = await prisma.userPreferences.findUnique({
+    // Upsert instead of findUnique-then-create: two concurrent first-load
+    // requests for a user with no preferences row yet would otherwise both
+    // see `null` and both attempt a create, and the loser throws a unique
+    // constraint violation on userId (see #341).
+    const preferences = await prisma.userPreferences.upsert({
       where: { userId },
-      include: {
-        avoidedIngredients: {
-          select: {
-            id: true,
-            name: true,
-            category: true,
-          },
+      update: {},
+      create: {
+        userId,
+        weeklyBudget: null,
+        preferredCuisines: [],
+        cookingSkillLevel: 'beginner',
+        maxPrepTimeWeeknight: 45,
+        maxPrepTimeWeekend: 90,
+        dietaryPreferences: {},
+        notificationSettings: {
+          mealReminders: true,
+          groceryReminders: true,
+          expirationAlerts: true,
         },
       },
+      include: PREFERENCES_INCLUDE,
     });
-
-    // Create default preferences if they don't exist
-    if (!preferences) {
-      preferences = await prisma.userPreferences.create({
-        data: {
-          userId,
-          weeklyBudget: null,
-          preferredCuisines: [],
-          cookingSkillLevel: 'beginner',
-          maxPrepTimeWeeknight: 45,
-          maxPrepTimeWeekend: 90,
-          dietaryPreferences: {},
-          notificationSettings: {
-            mealReminders: true,
-            groceryReminders: true,
-            expirationAlerts: true,
-          },
-        },
-        include: {
-          avoidedIngredients: {
-            select: {
-              id: true,
-              name: true,
-              category: true,
-            },
-          },
-        },
-      });
-    }
 
     res.json({
       data: preferences,


### PR DESCRIPTION
## Summary
- `GET /api/users/preferences` did `findUnique` then `create` if no row existed. Two near-simultaneous first-load requests for the same user both see `null` and both attempt `create`; the second hits the unique constraint on `userId`.
- This reproduces exactly the Postgres error seen in e2e CI logs: `duplicate key value violates unique constraint "user_preferences_user_id_key"`.
- Switched to `upsert`, matching the pattern already used in `updatePreferences`, and reused the existing `PREFERENCES_INCLUDE` constant instead of duplicating the include shape inline.

## Investigation notes for #341
This addresses the seed/duplicate-key portion of the issue with a confirmed root cause and fix. I also checked:
- `useKeyboardShortcuts` (previously flagged for a memory-leak-prone inline-array dep) — already correctly memoized, not a contributor.
- e2e CI history over the last 100 runs (going back to 2026-07-02): **zero** successful runs in that window, across many unrelated commits — the widespread-timeout pattern predates the specific 5 runs cited in the issue and doesn't correlate with any single recent change I could find (checked the csrf-csrf swap in particular; it predates that too).
- A real, separate a11y regression exists (heading-order / missing h1 landmark on nearly every authenticated page) but that overlaps with existing P3 issue #307 rather than #341's scope, and isn't a timeout/duplicate-key cause.

Recommend re-running the full e2e suite once this merges to see how much of the timeout cascade clears, per the issue's own suggested next step. If a large chunk remains, it likely needs runtime profiling of a live CI run (e.g. checking whether one early failure/error state degrades the rest of the same worker's run) rather than further static investigation.

Fixes the duplicate-key portion of #341

## Test plan
- [x] `tsc --noEmit` passes (backend)
- [ ] Re-run e2e suite in CI and compare failure profile to baseline