### PR TITLE
feat(meal-plan): quick-add staple meals to the weekly planner

### DIFF
--- a/backend/src/controllers/mealPlan.controller.ts
+++ b/backend/src/controllers/mealPlan.controller.ts
@@ -390,6 +390,105 @@ export const addMealToPlan = async (
 };
 
 /**
+ * @route   POST /api/meal-plans/:id/meals/quick-add
+ * @desc    Quick-add a staple meal: creates a minimally-filled-in Recipe
+ *          (no ingredients/instructions required) and assigns it to a
+ *          meal plan slot in one step (issue #328). Ingredients can be
+ *          filled in later via the normal recipe edit flow.
+ * @access  Private
+ */
+export const quickAddMealToPlan = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const userId = req.user?.userId || req.user?.id;
+    if (!userId) {
+      throw new AppError('User not authenticated', 401);
+    }
+
+    const { id } = req.params as { id: string };
+    const { title, mealTypes, date, mealType, servings, notes, assignedCookId } = req.body;
+
+    if (!title || typeof title !== 'string' || !title.trim()) {
+      throw new AppError('Title is required', 400);
+    }
+    if (!Array.isArray(mealTypes) || mealTypes.length === 0) {
+      throw new AppError('At least one meal type category is required', 400);
+    }
+    if (!date || !mealType) {
+      throw new AppError('Date and meal type are required', 400);
+    }
+
+    const mealPlan = await prisma.mealPlan.findFirst({
+      where: { id, userId },
+    });
+    if (!mealPlan) {
+      throw new AppError('Meal plan not found', 404);
+    }
+
+    const resolvedServings = servings || 4;
+
+    const meal = await prisma.$transaction(async (tx) => {
+      const recipe = await tx.recipe.create({
+        data: {
+          userId,
+          title: title.trim(),
+          source: 'custom',
+          prepTime: 0,
+          cookTime: 0,
+          servings: resolvedServings,
+          difficulty: 'easy',
+          mealTypes,
+          instructions: [],
+          kidFriendly: false,
+        },
+      });
+
+      return tx.plannedMeal.create({
+        data: {
+          mealPlanId: id,
+          recipeId: recipe.id,
+          date: new Date(date),
+          mealType,
+          servings: resolvedServings,
+          notes,
+          assignedCookId,
+        },
+        include: {
+          recipe: true,
+          assignedCook: true,
+        },
+      });
+    });
+
+    logger.info(`Staple meal quick-added to plan ${id}: ${meal.id} by user ${userId}`);
+    await cacheDelPattern(`meal-plans:${userId}:*`);
+
+    try {
+      const wsService = getWebSocketService();
+      wsService.broadcastMealPlanUpdate({
+        type: 'meal_added',
+        mealPlanId: id,
+        data: meal,
+        userId,
+        timestamp: new Date().toISOString(),
+      }, userId);
+    } catch (error) {
+      logger.warn('Failed to broadcast meal plan update:', error);
+    }
+
+    res.status(201).json({
+      success: true,
+      data: meal,
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
  * @route   PUT /api/meal-plans/:planId/meals/:mealId
  * @desc    Update meal in meal plan
  * @access  Private

--- a/backend/src/routes/mealPlan.routes.ts
+++ b/backend/src/routes/mealPlan.routes.ts
@@ -13,6 +13,7 @@ import {
   updateMealPlan,
   deleteMealPlan,
   addMealToPlan,
+  quickAddMealToPlan,
   updateMeal,
   removeMealFromPlan,
   batchCookMeal,
@@ -65,6 +66,14 @@ router.delete('/:id', deleteMealPlan);
  * @access  Private
  */
 router.post('/:id/meals', addMealToPlan);
+
+/**
+ * @route   POST /api/meal-plans/:id/meals/quick-add
+ * @desc    Quick-add a staple meal (creates a minimal Recipe + assigns it
+ *          to the slot in one step) — issue #328
+ * @access  Private
+ */
+router.post('/:id/meals/quick-add', quickAddMealToPlan);
 
 /**
  * @route   PUT /api/meal-plans/:planId/meals/:mealId

--- a/frontend/src/__tests__/pages/Profile.test.tsx
+++ b/frontend/src/__tests__/pages/Profile.test.tsx
@@ -21,10 +21,16 @@ vi.mock('../../services/api', () => {
     getStockImages: vi.fn(),
     setupStockVisualPassword: vi.fn(),
   };
-  return { userAPI, familyMemberAPI, visualAuthAPI };
+  const mealTypeOptionsAPI = {
+    getAll: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+  return { userAPI, familyMemberAPI, visualAuthAPI, mealTypeOptionsAPI };
 });
 
-import { userAPI, familyMemberAPI, visualAuthAPI } from '../../services/api';
+import { userAPI, familyMemberAPI, visualAuthAPI, mealTypeOptionsAPI } from '../../services/api';
 
 const mockProfile = { id: 'u1', email: 'admin@test.com', familyName: 'Test Fam' };
 const mockPreferences = {
@@ -37,6 +43,7 @@ function setupApiMocks(members = defaultMembers()) {
   (userAPI.getProfile as any).mockResolvedValue({ data: { data: mockProfile } });
   (userAPI.getPreferences as any).mockResolvedValue({ data: { data: mockPreferences } });
   (familyMemberAPI.getAll as any).mockResolvedValue({ data: { data: members } });
+  (mealTypeOptionsAPI.getAll as any).mockResolvedValue({ data: { data: [] } });
 }
 
 function defaultMembers() {

--- a/frontend/src/pages/MealPlanner.tsx
+++ b/frontend/src/pages/MealPlanner.tsx
@@ -30,6 +30,7 @@ import {
   CircularProgress,
   Link,
   Tooltip,
+  Alert,
 } from '@mui/material';
 import {
   Add as AddIcon,
@@ -53,7 +54,7 @@ import { DndContext, DragOverlay, PointerSensor, useSensor, useSensors, useDragg
 import { mealPlanAPI } from '../services/api';
 import type { MealPlan, PlannedMeal } from '../store/slices/mealPlansSlice';
 import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
-import { recipeAPI, familyMemberAPI, groceryListAPI } from '../services/api';
+import { recipeAPI, familyMemberAPI, groceryListAPI, mealTypeOptionsAPI } from '../services/api';
 import BatchCookingDialog from '../components/BatchCookingDialog';
 import { websocketService } from '../services/websocket.service';
 import type { MealPlanUpdate } from '../services/websocket.service';
@@ -137,6 +138,15 @@ const MealPlanner: React.FC = () => {
   const [recipeSearchInput, setRecipeSearchInput] = useState('');
   const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Quick-add staple meal state (issue #328) — when the recipe search comes
+  // up empty and the user typed a custom name, offer to quick-add it as a
+  // minimal recipe (no ingredients/instructions required) and schedule it
+  // in one step. The one required follow-up is a category, sourced from
+  // the household's user-editable meal type list (issue #327).
+  const [mealTypeOptions, setMealTypeOptions] = useState<string[]>([]);
+  const [quickAddCategories, setQuickAddCategories] = useState<string[]>([]);
+  const [quickAdding, setQuickAdding] = useState(false);
+
   // Meal detail dialog state
   const [openMealDetail, setOpenMealDetail] = useState(false);
   const [selectedMeal, setSelectedMeal] = useState<Meal | null>(null);
@@ -181,7 +191,8 @@ const MealPlanner: React.FC = () => {
   useEffect(() => {
     loadRecipes('');
     loadFamilyMembers();
-    
+    loadMealTypeOptions();
+
     // Cleanup timeout on unmount
     return () => {
       if (searchTimeoutRef.current) {
@@ -382,7 +393,17 @@ const MealPlanner: React.FC = () => {
       setFamilyMembersLoading(false);
     }
   };
-  
+
+  const loadMealTypeOptions = async () => {
+    try {
+      const response = await mealTypeOptionsAPI.getAll();
+      setMealTypeOptions((response.data.data || []).map((o: { name: string }) => o.name));
+    } catch (error) {
+      if (import.meta.env.DEV) console.error('Failed to load meal type categories:', error);
+      setMealTypeOptions([]);
+    }
+  };
+
   const ensureMealPlanExists = async (): Promise<string> => {
     if (currentMealPlanId) {
       return currentMealPlanId;
@@ -420,6 +441,7 @@ const MealPlanner: React.FC = () => {
     setSelectedMealType(mealType);
     setNewMeal({ recipeId: '', recipeName: '', servings: 4, assignedCookId: '' });
     setRecipeSearchInput('');
+    setQuickAddCategories([]);
     // Load initial recipes when opening dialog
     loadRecipes('');
     setOpenDialog(true);
@@ -430,7 +452,7 @@ const MealPlanner: React.FC = () => {
 
     try {
       const mealPlanId = await ensureMealPlanExists();
-      
+
       await mealPlanAPI.addMeal(mealPlanId, {
         recipeId: newMeal.recipeId,
         date: formatDateForAPI(selectedDate),
@@ -441,13 +463,47 @@ const MealPlanner: React.FC = () => {
 
       // Reload meals from server to ensure consistency
       await loadMealsForWeek();
-      
+
       setOpenDialog(false);
       setIsEditingMeal(false);
       setEditingMealId(null);
     } catch (error) {
       if (import.meta.env.DEV) console.error('Failed to add meal:', error);
       alert('Failed to add meal. Please try again.');
+    }
+  };
+
+  // Quick-add a staple meal (issue #328): the recipe search came up empty,
+  // the user typed a custom name instead, and picked at least one category.
+  const handleQuickAddMeal = async () => {
+    if (!selectedDate || !newMeal.recipeName.trim() || quickAddCategories.length === 0) return;
+
+    try {
+      setQuickAdding(true);
+      const mealPlanId = await ensureMealPlanExists();
+
+      await mealPlanAPI.quickAddMeal(mealPlanId, {
+        title: newMeal.recipeName.trim(),
+        mealTypes: quickAddCategories,
+        date: formatDateForAPI(selectedDate),
+        mealType: selectedMealType.toLowerCase(),
+        servings: newMeal.servings,
+        assignedCookId: newMeal.assignedCookId || undefined,
+      });
+
+      // Reload meals and the recipe list so the new staple recipe is
+      // findable next time without another quick-add.
+      await Promise.all([loadMealsForWeek(), loadRecipes('')]);
+
+      setOpenDialog(false);
+      setIsEditingMeal(false);
+      setEditingMealId(null);
+      setQuickAddCategories([]);
+    } catch (error) {
+      if (import.meta.env.DEV) console.error('Failed to quick-add meal:', error);
+      alert('Failed to quick-add meal. Please try again.');
+    } finally {
+      setQuickAdding(false);
     }
   };
 
@@ -1193,6 +1249,7 @@ const MealPlanner: React.FC = () => {
                     recipeName: value.title,
                     servings: value.servings
                   });
+                  setQuickAddCategories([]);
                 }
               }}
               loading={recipeSearchLoading}
@@ -1228,6 +1285,29 @@ const MealPlanner: React.FC = () => {
                 </li>
               )}
             />
+            {!isEditingMeal && !newMeal.recipeId && newMeal.recipeName.trim() && (
+              <Box>
+                <Alert severity="info" sx={{ mb: 1.5 }}>
+                  No recipe found for "{newMeal.recipeName.trim()}". Quick-add it as a staple meal —
+                  you can add ingredients later so it shows up in your grocery list.
+                </Alert>
+                <Autocomplete
+                  multiple
+                  options={mealTypeOptions}
+                  value={quickAddCategories}
+                  onChange={(_, value) => setQuickAddCategories(value)}
+                  renderInput={(params) => (
+                    <TextField
+                      {...params}
+                      label="Category"
+                      required
+                      error={quickAddCategories.length === 0}
+                      helperText={quickAddCategories.length === 0 ? 'Pick at least one category' : ''}
+                    />
+                  )}
+                />
+              </Box>
+            )}
             <TextField
               select
               label="Assigned Cook"
@@ -1259,13 +1339,30 @@ const MealPlanner: React.FC = () => {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => { setOpenDialog(false); setIsEditingMeal(false); setEditingMealId(null); }}>Cancel</Button>
-          <Button
-            onClick={isEditingMeal ? handleUpdateMeal : handleAddMeal}
-            variant="contained"
-            disabled={!newMeal.recipeId || !newMeal.recipeName}
-          >
-            {isEditingMeal ? 'Update Meal' : 'Add Meal'}
-          </Button>
+          {(() => {
+            const isQuickAdd = !isEditingMeal && !newMeal.recipeId && newMeal.recipeName.trim().length > 0;
+            if (isQuickAdd) {
+              return (
+                <Button
+                  onClick={handleQuickAddMeal}
+                  variant="contained"
+                  disabled={quickAddCategories.length === 0 || quickAdding}
+                  startIcon={quickAdding ? <CircularProgress size={16} color="inherit" /> : undefined}
+                >
+                  Quick-Add & Schedule
+                </Button>
+              );
+            }
+            return (
+              <Button
+                onClick={isEditingMeal ? handleUpdateMeal : handleAddMeal}
+                variant="contained"
+                disabled={!newMeal.recipeId || !newMeal.recipeName}
+              >
+                {isEditingMeal ? 'Update Meal' : 'Add Meal'}
+              </Button>
+            );
+          })()}
         </DialogActions>
       </Dialog>
 

--- a/frontend/src/pages/Recipes.tsx
+++ b/frontend/src/pages/Recipes.tsx
@@ -44,6 +44,7 @@ import {
   Info as InfoIcon,
   CleaningServices as CleaningServicesIcon,
   Clear as ClearIcon,
+  ShoppingCart as ShoppingCartIcon,
 } from '@mui/icons-material';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
@@ -61,10 +62,12 @@ import RecipeDiscoveryEmptyState from '../components/RecipeDiscoveryEmptyState';
 interface RecipeCardProps {
   recipe: Recipe;
   onNavigate: (id: string) => void;
+  onEditIngredients: (id: string) => void;
 }
 
-const RecipeCard = memo(({ recipe, onNavigate }: RecipeCardProps) => {
+const RecipeCard = memo(({ recipe, onNavigate, onEditIngredients }: RecipeCardProps) => {
   const { src: imageSrc, isLoading: imageLoading } = useCachedImage(recipe.imageUrl);
+  const needsIngredients = recipe.ingredients.length === 0;
 
   const getDifficultyColor = (diff: string) => {
     switch (diff.toLowerCase()) {
@@ -134,6 +137,11 @@ const RecipeCard = memo(({ recipe, onNavigate }: RecipeCardProps) => {
           {recipe.description || 'No description available'}
         </Typography>
         <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', gap: 1 }}>
+          {needsIngredients && (
+            <Tooltip title="Quick-added without ingredients — add them so this shows up in your grocery list" arrow>
+              <Chip icon={<ShoppingCartIcon />} label="Needs ingredients" size="small" color="primary" />
+            </Tooltip>
+          )}
           <Tooltip title={`Difficulty: ${recipe.difficulty}`} arrow>
             <Chip label={recipe.difficulty} size="small" color={getDifficultyColor(recipe.difficulty)} />
           </Tooltip>
@@ -148,13 +156,25 @@ const RecipeCard = memo(({ recipe, onNavigate }: RecipeCardProps) => {
         </Stack>
       </CardContent>
       <CardActions>
-        <Button
-          size="small"
-          onClick={(e) => { e.stopPropagation(); onNavigate(recipe.id); }}
-          aria-label={`View ${recipe.title} recipe`}
-        >
-          View Recipe
-        </Button>
+        {needsIngredients ? (
+          <Button
+            size="small"
+            color="primary"
+            startIcon={<ShoppingCartIcon />}
+            onClick={(e) => { e.stopPropagation(); onEditIngredients(recipe.id); }}
+            aria-label={`Add ingredients to ${recipe.title} so it shows up in your grocery list`}
+          >
+            Add ingredients for grocery list
+          </Button>
+        ) : (
+          <Button
+            size="small"
+            onClick={(e) => { e.stopPropagation(); onNavigate(recipe.id); }}
+            aria-label={`View ${recipe.title} recipe`}
+          >
+            View Recipe
+          </Button>
+        )}
       </CardActions>
     </Card>
   );
@@ -199,18 +219,32 @@ const Recipes: React.FC = () => {
   // Filter panel open/closed
   const [filtersOpen, setFiltersOpen] = useState(false);
 
+  // "My Staples" view (issue #328) — quick-added staple meals are just
+  // recipes with no ingredients yet. Not a separate page, a filter here.
+  const [needsIngredientsOnly, setNeedsIngredientsOnly] = useState(false);
+  const staplesNeedingIngredientsCount = useMemo(
+    () => recipes.filter((r) => r.ingredients.length === 0).length,
+    [recipes]
+  );
+
   const debouncedSearch = useDebounce(searchInput, 300);
 
   // Client-side filter of already-loaded recipes by search text
   const displayedRecipes = useMemo(() => {
-    if (!debouncedSearch.trim()) return recipes;
-    const term = debouncedSearch.trim().toLowerCase();
-    return recipes.filter(
-      (r) =>
-        r.title.toLowerCase().includes(term) ||
-        (r.description && r.description.toLowerCase().includes(term))
-    );
-  }, [recipes, debouncedSearch]);
+    let result = recipes;
+    if (needsIngredientsOnly) {
+      result = result.filter((r) => r.ingredients.length === 0);
+    }
+    if (debouncedSearch.trim()) {
+      const term = debouncedSearch.trim().toLowerCase();
+      result = result.filter(
+        (r) =>
+          r.title.toLowerCase().includes(term) ||
+          (r.description && r.description.toLowerCase().includes(term))
+      );
+    }
+    return result;
+  }, [recipes, debouncedSearch, needsIngredientsOnly]);
 
   const activeFilterCount = [difficulty, mealType, cleanupScore].filter(Boolean).length;
 
@@ -253,6 +287,7 @@ const Recipes: React.FC = () => {
   }, []);
 
   const handleNavigate = useCallback((id: string) => navigate(`/recipes/${id}`), [navigate]);
+  const handleEditIngredients = useCallback((id: string) => navigate(`/recipes/${id}/edit`), [navigate]);
 
   const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => setActiveTab(newValue);
 
@@ -366,6 +401,18 @@ const Recipes: React.FC = () => {
                   Filters
                 </Button>
               </Badge>
+              {staplesNeedingIngredientsCount > 0 && (
+                <Tooltip title="Staple meals you quick-added without ingredients — add them so they show up in your grocery list" arrow>
+                  <Chip
+                    icon={<ShoppingCartIcon />}
+                    label={`Needs Ingredients (${staplesNeedingIngredientsCount})`}
+                    color={needsIngredientsOnly ? 'primary' : 'default'}
+                    variant={needsIngredientsOnly ? 'filled' : 'outlined'}
+                    onClick={() => { setNeedsIngredientsOnly((v) => !v); setCurrentPage(1); }}
+                    sx={{ whiteSpace: 'nowrap' }}
+                  />
+                </Tooltip>
+              )}
               <FormControl sx={{ minWidth: 180 }}>
                 <InputLabel>Sort By</InputLabel>
                 <Select
@@ -500,7 +547,7 @@ const Recipes: React.FC = () => {
               {[...Array(8)].map((_, index) => <RecipeCardSkeleton key={index} />)}
             </Box>
           ) : displayedRecipes.length === 0 ? (
-            !searchInput && !difficulty && !mealType && !cleanupScore ? (
+            !searchInput && !difficulty && !mealType && !cleanupScore && !needsIngredientsOnly ? (
               <RecipeDiscoveryEmptyState />
             ) : (
               <Box sx={{ textAlign: 'center', py: 8 }}>
@@ -522,7 +569,7 @@ const Recipes: React.FC = () => {
                 }}
               >
                 {displayedRecipes.map((recipe) => (
-                  <RecipeCard key={recipe.id} recipe={recipe} onNavigate={handleNavigate} />
+                  <RecipeCard key={recipe.id} recipe={recipe} onNavigate={handleNavigate} onEditIngredients={handleEditIngredients} />
                 ))}
               </Box>
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -205,7 +205,17 @@ export const mealPlanAPI = {
     assignedCookId?: string;
     notes?: string;
   }) => api.post(`/meal-plans/${id}/meals`, data),
-  
+
+  quickAddMeal: (id: string, data: {
+    title: string;
+    mealTypes: string[];
+    date: string;
+    mealType: string;
+    servings?: number;
+    assignedCookId?: string;
+    notes?: string;
+  }) => api.post(`/meal-plans/${id}/meals/quick-add`, data),
+
   updateMeal: (planId: string, mealId: string, data: Record<string, unknown>) =>
     api.put(`/meal-plans/${planId}/meals/${mealId}`, data),
   


### PR DESCRIPTION
## Summary
Lets a user type a familiar meal's name once, drop it onto a day/slot immediately, and add ingredients later — never as a blocker to saving or scheduling it.

**Depends on #344 (#327)** — targets that branch since it needs the meal-type category picker. Rebase onto `main` once #344 merges.

## What's implemented

**1. Inline quick-add in the existing "Add Meal" dialog**
The weekly planner's Add Meal dialog already has a `freeSolo` recipe-name Autocomplete whose free text just couldn't be saved (the button stayed disabled). Now, when there's no match: "No recipe found — quick-add it as a staple meal" plus the one required follow-up — a category picker sourced from the household's meal-type list (#327) — and the button becomes "Quick-Add & Schedule", creating the recipe and assigning it to the slot in one call.

**2. "My Staples" view**
Not a new page — a quick-added staple *is* a Recipe, just a minimally-filled-in one. `Recipes.tsx` gets a "Needs Ingredients" toggle chip (only shown when the count is > 0) that filters to recipes with zero ingredients, plus a per-card CTA framed around the actual payoff: "Add ingredients for grocery list" instead of generic recipe editing.

**Backend**: new `POST /api/meal-plans/:id/meals/quick-add` — creates a minimal Recipe (title + category, `prepTime`/`cookTime` 0, `difficulty: 'easy'`, no ingredients, empty instructions) and a `PlannedMeal` in one transaction. Mirrors the existing `addMealToPlan`'s not-found/broadcast/cache-invalidation handling.

## Scope cut — called out explicitly
The issue's proposed UX also describes a lightweight, line-by-line quick ingredient entry with soft-matching against the ingredient catalog — "the reason this issue exists," in the issue's own words. **That's not built in this PR.** "Add ingredients" currently routes to the existing full `CreateRecipe` wizard, which still gates progression on adding an instruction step too (the wizard itself is untouched — the issue explicitly puts redesigning it out of scope).

So: the core "get it on the calendar with zero friction" goal is fully delivered. The "flesh it out later" path works today but isn't yet the lightweight experience the issue envisions — recommend a fast-follow issue for the quick ingredient entry component rather than blocking this PR on it.

## Verification
Ran end-to-end against a throwaway Postgres 16 container (real HTTP requests, not just typecheck):
- `quick-add` creates the recipe with `ingredients: []` and schedules it to the plan in one call.
- The recipe list reflects `ingredients: []`, so the "Needs Ingredients" filter picks it up correctly.

## Test plan
- [x] Backend `tsc --noEmit` passes
- [x] Frontend `tsc --noEmit` passes
- [x] Backend test suite (162 tests) passes
- [x] Lint clean (no new warnings)
- [x] Manual end-to-end verification against a real Postgres instance (see above)
- [ ] Manual UI smoke test (Add Meal dialog quick-add flow, Recipes "Needs Ingredients" filter)