### PR TITLE
fix(e2e): resolve widespread e2e failures

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -7,6 +7,7 @@ import 'dotenv/config';
 import { PrismaClient } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 import bcrypt from 'bcryptjs';
+import { seedRecipes } from '../seed-recipes';
 
 const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
 const prisma = new PrismaClient({ adapter });
@@ -48,7 +49,30 @@ async function main() {
   if (recipeCount > 0) {
     console.log(`✓ Found ${recipeCount} existing recipes for test user`);
   } else {
-    console.log('✓ No recipes found, they will be created by seed-recipes.ts if needed');
+    await seedRecipes(prisma);
+  }
+
+  // The visual login picker (/login) lists FamilyMember rows, not User rows
+  // directly — without at least one, it finds zero entries and redirects
+  // straight to /welcome (fresh-install flow), never actually showing the
+  // picker screen e2e tests expect to interact with.
+  const familyMemberCount = await prisma.familyMember.count({
+    where: { userId: TEST_USER_ID },
+  });
+
+  if (familyMemberCount > 0) {
+    console.log(`✓ Found ${familyMemberCount} existing family members for test user`);
+  } else {
+    await prisma.familyMember.create({
+      data: {
+        userId: TEST_USER_ID,
+        name: 'Test User',
+        ageGroup: 'adult',
+        canCook: true,
+        dietaryRestrictions: [],
+      },
+    });
+    console.log('✓ Created family member: Test User');
   }
 
   console.log('✅ Database seeding completed successfully!');

--- a/backend/seed-recipes.ts
+++ b/backend/seed-recipes.ts
@@ -2,9 +2,6 @@ import 'dotenv/config';
 import { PrismaClient, Difficulty, MealType } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 
-const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
-const prisma = new PrismaClient({ adapter });
-
 const TEST_USER_ID = 'test-user-00-0000-0000-000000000001'; // The test user from database init
 
 const recipes = [
@@ -57,9 +54,9 @@ const recipes = [
   { title: 'Lemon Bars', description: 'Tangy lemon bars with shortbread crust', prepTime: 15, cookTime: 45, servings: 16, difficulty: 'easy', kidFriendly: true, cuisineType: 'American', mealTypes: ['dessert'] },
 ];
 
-async function main() {
+export async function seedRecipes(prisma: PrismaClient) {
   console.log('Seeding database with 40 test recipes...');
-  
+
   for (const recipe of recipes) {
     await prisma.recipe.create({
       data: {
@@ -79,18 +76,24 @@ async function main() {
     });
     console.log(`✓ Created: ${recipe.title}`);
   }
-  
+
   const count = await prisma.recipe.count();
   console.log(`\n✅ Successfully created ${count} recipes!`);
 }
 
-main()
-  .catch((e) => {
-    console.error('Error seeding database:', e);
-    process.exit(1);
-  })
-  .finally(async () => {
-    await prisma.$disconnect();
-  });
+// Allow running standalone (`ts-node seed-recipes.ts`) for manual/local reseeding.
+if (require.main === module) {
+  const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
+  const prisma = new PrismaClient({ adapter });
+
+  seedRecipes(prisma)
+    .catch((e) => {
+      console.error('Error seeding database:', e);
+      process.exit(1);
+    })
+    .finally(async () => {
+      await prisma.$disconnect();
+    });
+}
 
 // Made with Bob

--- a/frontend/e2e/helpers/test-data.ts
+++ b/frontend/e2e/helpers/test-data.ts
@@ -1,7 +1,7 @@
 import { APIRequestContext } from '@playwright/test';
 
 export interface TestRecipe {
-  id: number;
+  id: string;
   title: string;
 }
 
@@ -13,8 +13,15 @@ const BASE_RECIPE = {
   servings: 4,
   difficulty: 'easy',
   mealTypes: ['dinner'],
-  instructions: '1. Test step',
-  ingredients: [],
+  // Array form (not a plain string) — CreateRecipe's edit-mode loader only
+  // recognizes `Array.isArray(recipe.instructions)`, otherwise it treats the
+  // recipe as having no instructions at all, which blocks the edit wizard's
+  // own step validation.
+  instructions: [{ step: 1, instruction: 'Test step' }],
+  // At least one ingredient — the edit wizard's Ingredients step requires
+  // one to advance, and a recipe created with none can't otherwise reach
+  // its own Instructions/Review steps in edit mode.
+  ingredients: [{ ingredientName: 'Test Ingredient', quantity: 1, unit: 'unit' }],
 };
 
 /**
@@ -46,7 +53,7 @@ export async function createTestRecipe(
   return { id: data.id, title: data.title };
 }
 
-export async function deleteTestRecipe(api: APIRequestContext, id: number): Promise<void> {
+export async function deleteTestRecipe(api: APIRequestContext, id: string): Promise<void> {
   const csrfToken = await fetchCsrfToken(api);
   await api.delete(`/api/recipes/${id}`, {
     headers: { 'X-CSRF-Token': csrfToken },

--- a/frontend/e2e/mocks/spoonacular.mock.ts
+++ b/frontend/e2e/mocks/spoonacular.mock.ts
@@ -65,10 +65,23 @@ export const mockSpoonacularAPI = async (page: Page) => {
     });
   });
 
-  // Mock recipe details endpoint
-  await page.route('**/api/recipes/browse/*', async (route) => {
+  // Mock recipe details / add-to-box endpoints. Must be `**` (not `*`) —
+  // add-to-box is a segment deeper (`/browse/{id}/add-to-box`), and a single
+  // `*` can't cross the extra `/`, so it would silently fall through to the
+  // real (unconfigured) backend and 503 instead of being mocked.
+  await page.route('**/api/recipes/browse/**', async (route) => {
     const url = route.request().url();
     const recipeId = url.match(/\/browse\/(\d+)/)?.[1];
+
+    // Routes are matched most-recently-registered-first, and this glob
+    // (`/browse/*`) also matches `/browse/search`. Without this guard, every
+    // search request gets silently swallowed by the details mock below and
+    // answered with a single bogus "Mock Recipe undefined" object instead of
+    // falling through to the dedicated search handler registered above.
+    if (!recipeId) {
+      await route.fallback();
+      return;
+    }
 
     if (route.request().method() === 'GET') {
       const mockResponse = {

--- a/frontend/e2e/page-objects/RecipesPage.ts
+++ b/frontend/e2e/page-objects/RecipesPage.ts
@@ -23,7 +23,7 @@ export class RecipesPage {
 
   constructor(page: Page) {
     this.page = page;
-    this.searchInput = page.getByPlaceholder(/search recipes/i);
+    this.searchInput = page.getByPlaceholder(/search (my )?recipes/i);
     this.filterButton = page.getByRole('button', { name: /filter/i });
     // Issue #138: Fixed sort dropdown selector to work with MUI Select component
     // Use a more robust selector that finds the Select by its label

--- a/frontend/e2e/tests/accessibility/a11y.spec.ts
+++ b/frontend/e2e/tests/accessibility/a11y.spec.ts
@@ -7,6 +7,22 @@ const GLOBAL_SKIPPED_RULES = [
   'color-contrast', // MUI theme contrast checked via Lighthouse CI instead
 ];
 
+// A fresh page.goto() on a protected route forces a full app remount:
+// PrivateRoute's auth check and SetupGuard's /setup/status check each gate
+// rendering behind their own sequential network round-trip, replacing the
+// whole tree with a bare, unlabeled CircularProgress in the meantime (no
+// <main>, no heading). Several page components (GroceryList, etc.) have
+// their own `if (loading) return <spinner-only>` on top of that. Either gap
+// can exceed Playwright's networkidle quiet window, so networkidle alone
+// can resolve while the app is still in a transient, non-landmarked loading
+// state. Waiting for an h1 to attach ensures axe runs against the real,
+// settled page instead of one of those flashes.
+async function waitForAppReady(page: Parameters<typeof AxeBuilder>[0]) {
+  await page.waitForLoadState('networkidle');
+  await page.waitForSelector('#main-content', { state: 'attached', timeout: 10000 });
+  await page.waitForSelector('h1', { state: 'attached', timeout: 10000 });
+}
+
 async function checkA11y(
   page: Parameters<typeof AxeBuilder>[0],
   context?: string
@@ -33,7 +49,11 @@ test.describe('Accessibility — unauthenticated pages', () => {
 
   test('login page has no WCAG violations', async ({ page }) => {
     await page.goto('/login');
+    // LocalLogin does its own sequential device-login-then-list-users check
+    // before rendering the picker — same transient, non-landmarked loading
+    // flash as the authenticated pages (see waitForAppReady above).
     await page.waitForLoadState('networkidle');
+    await page.waitForSelector('h1', { state: 'attached', timeout: 10000 });
     await checkA11y(page, 'login page');
   });
 });
@@ -46,43 +66,47 @@ test.describe('Accessibility — authenticated pages', () => {
 
   test('recipes list has no WCAG violations', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/recipes');
-    await authenticatedPage.waitForLoadState('networkidle');
+    await waitForAppReady(authenticatedPage);
     await checkA11y(authenticatedPage, 'recipes list');
   });
 
   test('create recipe form has no WCAG violations', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/recipes/create');
-    await authenticatedPage.waitForLoadState('networkidle');
+    await waitForAppReady(authenticatedPage);
     await checkA11y(authenticatedPage, 'create recipe form');
   });
 
   test('meal plan page has no WCAG violations', async ({ authenticatedPage }) => {
-    await authenticatedPage.goto('/meal-plan');
-    await authenticatedPage.waitForLoadState('networkidle');
+    // Note: the real route is /meal-planner, not /meal-plan — the latter
+    // hits the app's catch-all redirect and silently re-tests /dashboard.
+    await authenticatedPage.goto('/meal-planner');
+    await waitForAppReady(authenticatedPage);
     await checkA11y(authenticatedPage, 'meal plan page');
   });
 
   test('grocery list page has no WCAG violations', async ({ authenticatedPage }) => {
-    await authenticatedPage.goto('/grocery-lists');
-    await authenticatedPage.waitForLoadState('networkidle');
+    // Note: the real route is /grocery-list (singular), not /grocery-lists.
+    await authenticatedPage.goto('/grocery-list');
+    await waitForAppReady(authenticatedPage);
     await checkA11y(authenticatedPage, 'grocery list page');
   });
 
   test('pantry page has no WCAG violations', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/pantry');
-    await authenticatedPage.waitForLoadState('networkidle');
+    await waitForAppReady(authenticatedPage);
     await checkA11y(authenticatedPage, 'pantry page');
   });
 
   test('profile page has no WCAG violations', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/profile');
-    await authenticatedPage.waitForLoadState('networkidle');
+    await waitForAppReady(authenticatedPage);
     await checkA11y(authenticatedPage, 'profile page');
   });
 
   test('browse recipes page has no WCAG violations', async ({ authenticatedPage }) => {
-    await authenticatedPage.goto('/browse');
-    await authenticatedPage.waitForLoadState('networkidle');
+    // Note: the real route is /recipes/browse, not /browse.
+    await authenticatedPage.goto('/recipes/browse');
+    await waitForAppReady(authenticatedPage);
     await checkA11y(authenticatedPage, 'browse recipes page');
   });
 });
@@ -94,7 +118,10 @@ test.describe('Keyboard navigation', () => {
     test.use({ storageState: { cookies: [], origins: [] } });
 
     test('login form is keyboard navigable', async ({ page }) => {
-      await page.goto('/login');
+      // /login is the visual family-member-picker screen (no email/password
+      // fields at all); the classic email/password form lives at
+      // /login/classic.
+      await page.goto('/login/classic');
       await page.waitForLoadState('networkidle');
 
       await page.keyboard.press('Tab');
@@ -110,7 +137,9 @@ test.describe('Keyboard navigation', () => {
   test('navigation links receive focus', async ({ authenticatedPage }) => {
     await authenticatedPage.waitForLoadState('networkidle');
 
-    const navLinks = authenticatedPage.locator('nav a, nav button, [role="navigation"] a');
+    // MUI's ListItemButton renders as a <div role="button"> (not a real
+    // <button>) here, so the selector must also match ARIA-button divs.
+    const navLinks = authenticatedPage.locator('nav a, nav button, nav [role="button"], [role="navigation"] a');
     const count = await navLinks.count();
     expect(count).toBeGreaterThan(0);
   });

--- a/frontend/e2e/tests/auth/logout.spec.ts
+++ b/frontend/e2e/tests/auth/logout.spec.ts
@@ -8,13 +8,19 @@ test.describe('Logout Flow', () => {
     // Click logout
     await authenticatedPage.getByRole('menuitem', { name: /logout/i }).click();
 
-    // Should redirect to the local login page
-    await expect(authenticatedPage).toHaveURL('/login');
+    // Logout (Layout.tsx) navigates to the classic form, not the visual
+    // family-member-picker at /login.
+    await expect(authenticatedPage).toHaveURL('/login/classic');
   });
 
   test('should not access protected routes after logout', async ({ authenticatedPage }) => {
     await authenticatedPage.getByLabel('Profile & Family Settings').click();
     await authenticatedPage.getByRole('menuitem', { name: /logout/i }).click();
+
+    // Logout dispatches an async API call that clears the auth cookies —
+    // wait for it to actually complete before navigating, otherwise this
+    // races ahead and /dashboard loads with the still-valid session cookie.
+    await expect(authenticatedPage).toHaveURL('/login/classic');
 
     // Try to access a protected route
     await authenticatedPage.goto('/dashboard');
@@ -26,7 +32,7 @@ test.describe('Logout Flow', () => {
   test('should clear session on logout', async ({ authenticatedPage }) => {
     await authenticatedPage.getByLabel('Profile & Family Settings').click();
     await authenticatedPage.getByRole('menuitem', { name: /logout/i }).click();
-    await expect(authenticatedPage).toHaveURL('/login');
+    await expect(authenticatedPage).toHaveURL('/login/classic');
 
     // Attempting a protected route confirms the session cookie was cleared
     await authenticatedPage.goto('/recipes');

--- a/frontend/e2e/tests/ftue/ftue-audit.spec.ts
+++ b/frontend/e2e/tests/ftue/ftue-audit.spec.ts
@@ -77,7 +77,12 @@ test.describe('Visual Login Screen (/login)', () => {
   });
 
   test('user cards are displayed for family members', async ({ page }) => {
+    // The picker shows Skeleton placeholders (no buttons at all) while the
+    // family-member list is loading — networkidle in beforeEach doesn't
+    // guarantee that in-component fetch has resolved yet, so wait for an
+    // actual card before counting.
     const userCards = page.getByRole('button').filter({ hasText: /\w+/ });
+    await userCards.first().waitFor({ state: 'visible', timeout: 10000 });
     const count = await userCards.count();
     console.log(`Found ${count} user cards on login screen`);
     expect(count).toBeGreaterThan(0);

--- a/frontend/e2e/tests/ftue/ftue-audit.spec.ts
+++ b/frontend/e2e/tests/ftue/ftue-audit.spec.ts
@@ -51,7 +51,7 @@ test.describe('Visual Login Screen (/login)', () => {
   });
 
   test('#235 — branding should be consistent, not "Family Kitchen" vs "Family Meal Planner"', async ({ page }) => {
-    const heading = page.locator('h4, h3, h2').first();
+    const heading = page.locator('h1, h4, h3, h2').first();
     const text = await heading.textContent();
     // Document what the heading actually says
     console.log(`Login heading text: "${text}"`);

--- a/frontend/e2e/tests/recipes/browse-recipes.spec.ts
+++ b/frontend/e2e/tests/recipes/browse-recipes.spec.ts
@@ -19,8 +19,8 @@ test.describe('Browse Recipes', () => {
   });
 
   test('should display browse recipes page', async ({ page }) => {
-    // Check page title
-    await expect(page.locator('h4')).toContainText('Browse Recipes');
+    // Check page title (styled as h4, but semantically the page's h1)
+    await expect(page.locator('h1')).toContainText('Browse Recipes');
 
     // Check search input is visible
     await expect(page.getByPlaceholder(/Search recipes|Try:/)).toBeVisible();
@@ -37,26 +37,36 @@ test.describe('Browse Recipes', () => {
     await searchInput.fill('pasta');
 
     // Wait for debounce and results
-    await page.waitForTimeout(600); // Wait for debounce
+    await page.waitForTimeout(1000); // Wait for debounce
 
     // Check if results are displayed (mocked data should return 3 recipes)
     await expect(page.locator('[data-testid="recipe-card"]')).toHaveCount(3, { timeout: 5000 });
   });
 
   test('should display filter options', async ({ page }) => {
-    // Check filter controls are visible
-    await expect(page.getByText('Cuisine')).toBeVisible();
-    await expect(page.getByText('Diet')).toBeVisible();
-    await expect(page.getByText('Meal Type')).toBeVisible();
-    await expect(page.getByText('Sort By')).toBeVisible();
-    await expect(page.getByText('Max Cooking Time')).toBeVisible();
+    // Check filter controls are visible. Use getByLabel rather than
+    // getByText — MUI's outlined-select notch duplicates the label text
+    // into a legend for the border cutout, so getByText resolves to 2
+    // elements per field in strict mode.
+    await expect(page.getByLabel('Cuisine')).toBeVisible();
+    await expect(page.getByLabel('Diet')).toBeVisible();
+    await expect(page.getByLabel('Meal Type')).toBeVisible();
+    await expect(page.getByLabel('Sort By')).toBeVisible();
+    // No time filter is active by default, so "Max Time" text isn't
+    // rendered yet — the equivalent default-state affordance is this button.
+    await expect(page.getByRole('button', { name: /add time filter/i })).toBeVisible();
   });
 
   test('should apply cuisine filter', async ({ page }) => {
     // Search first
     const searchInput = page.getByPlaceholder(/Search recipes|Try:/);
     await searchInput.fill('pasta');
-    await page.waitForTimeout(600);
+    await page.waitForTimeout(1000);
+
+    // The natural-language search suggestions dropdown stays open after
+    // typing and visually overlaps the filters below it, which blocks
+    // clicks on them — dismiss it first (Escape is wired to close it).
+    await page.keyboard.press('Escape');
 
     // Open cuisine dropdown
     await page.getByLabel('Cuisine').click();
@@ -65,7 +75,7 @@ test.describe('Browse Recipes', () => {
     await page.getByRole('option', { name: 'Italian' }).click();
 
     // Wait for results to update
-    await page.waitForTimeout(600);
+    await page.waitForTimeout(1000);
 
     // Check URL contains cuisine parameter (case-insensitive)
     expect(page.url().toLowerCase()).toContain('cuisine=italian');
@@ -75,7 +85,8 @@ test.describe('Browse Recipes', () => {
     // Search first
     const searchInput = page.getByPlaceholder(/Search recipes|Try:/);
     await searchInput.fill('salad');
-    await page.waitForTimeout(600);
+    await page.waitForTimeout(1000);
+    await page.keyboard.press('Escape'); // dismiss search suggestions overlay
 
     // Open diet dropdown
     await page.getByLabel('Diet').click();
@@ -84,7 +95,7 @@ test.describe('Browse Recipes', () => {
     await page.getByRole('option', { name: 'Vegetarian' }).click();
 
     // Wait for results to update
-    await page.waitForTimeout(600);
+    await page.waitForTimeout(1000);
 
     // Check URL contains diet parameter (case-insensitive)
     expect(page.url().toLowerCase()).toContain('diet=vegetarian');
@@ -94,7 +105,8 @@ test.describe('Browse Recipes', () => {
     // Apply multiple filters
     const searchInput = page.getByPlaceholder(/Search recipes|Try:/);
     await searchInput.fill('chicken');
-    await page.waitForTimeout(600);
+    await page.waitForTimeout(1000);
+    await page.keyboard.press('Escape'); // dismiss search suggestions overlay
 
     await page.getByLabel('Cuisine').click();
     await page.getByRole('option', { name: 'American' }).click();
@@ -120,7 +132,8 @@ test.describe('Browse Recipes', () => {
     // Apply filters
     const searchInput = page.getByPlaceholder(/Search recipes|Try:/);
     await searchInput.fill('pasta');
-    await page.waitForTimeout(600);
+    await page.waitForTimeout(1000);
+    await page.keyboard.press('Escape'); // dismiss search suggestions overlay
 
     await page.getByLabel('Cuisine').click();
     await page.getByRole('option', { name: 'Italian' }).click();
@@ -144,7 +157,7 @@ test.describe('Browse Recipes', () => {
     // This test verifies the pagination component would work if there were more results
     const searchInput = page.getByPlaceholder(/Search recipes|Try:/);
     await searchInput.fill('pasta');
-    await page.waitForTimeout(600);
+    await page.waitForTimeout(1000);
 
     // Wait for results
     await page.waitForSelector('[data-testid="recipe-card"]', { timeout: 10000 }).catch(() => {});
@@ -160,12 +173,9 @@ test.describe('Browse Recipes', () => {
     const searchInput = page.getByPlaceholder(/Search recipes|Try:/);
     await searchInput.fill('pasta');
 
-    // Wait for results to load
-    await page.waitForTimeout(700);
-
-    // Verify results are displayed (mocked data)
-    const recipeCount = await page.locator('[data-testid="recipe-card"]').count();
-    expect(recipeCount).toBe(3);
+    // Verify results are displayed (mocked data) — toHaveCount retries
+    // instead of relying on a fixed delay to have been long enough.
+    await expect(page.locator('[data-testid="recipe-card"]')).toHaveCount(3, { timeout: 5000 });
   });
 });
 
@@ -178,19 +188,19 @@ test.describe('Browse Recipes - Add to Box', () => {
     // Search for recipes
     const searchInput = page.getByPlaceholder(/Search recipes|Try:/);
     await searchInput.fill('pasta');
-    await page.waitForTimeout(600);
+    await page.waitForTimeout(1000);
 
     // Wait for recipe cards (mocked data returns 3)
     await expect(page.locator('[data-testid="recipe-card"]')).toHaveCount(3, { timeout: 5000 });
 
-    // Click "Add to Box" on first recipe
-    await page.locator('[data-testid="recipe-card"]').first().getByRole('button', { name: /add to/i }).click();
+    // Click "Add" on first recipe
+    await page.locator('[data-testid="recipe-card"]').first().getByRole('button', { name: /^add$/i }).click();
 
     // Wait for success message
     await expect(page.getByText(/added to your recipe box/i)).toBeVisible({ timeout: 5000 });
 
-    // Button should change to "Added"
-    await expect(page.locator('[data-testid="recipe-card"]').first().getByRole('button', { name: /added/i })).toBeVisible();
+    // Button should change to "In Box"
+    await expect(page.locator('[data-testid="recipe-card"]').first().getByRole('button', { name: /in box/i })).toBeVisible();
   });
 });
 

--- a/frontend/e2e/tests/recipes/browse.spec.ts
+++ b/frontend/e2e/tests/recipes/browse.spec.ts
@@ -30,8 +30,8 @@ test.describe('Browse Recipes', () => {
     // Click the recipe
     await firstRecipe.click();
     
-    // Should navigate to recipe detail page
-    await expect(authenticatedPage).toHaveURL(/.*recipes\/\d+/);
+    // Should navigate to recipe detail page (recipe ids are UUIDs, not ints)
+    await expect(authenticatedPage).toHaveURL(/\/recipes\/[0-9a-f-]+$/);
     
     // Should show the recipe title
     if (title) {

--- a/frontend/e2e/tests/recipes/create.spec.ts
+++ b/frontend/e2e/tests/recipes/create.spec.ts
@@ -1,8 +1,14 @@
 import { test, expect } from '../../fixtures/auth.fixture';
 import { deleteTestRecipe } from '../../helpers/test-data';
 
+// CreateRecipe is a 4-step wizard (Basic Info -> Ingredients -> Instructions
+// -> Review), not a single-page form — these tests drive it step by step.
+// formData defaults already satisfy every Basic Info requirement except
+// title (prepTime/cookTime/servings/difficulty/mealTypes are pre-filled), so
+// only title needs to be set before advancing past step 0.
+
 test.describe('Create Recipe', () => {
-  let createdRecipeId: number | null = null;
+  let createdRecipeId: string | null = null;
 
   test.afterEach(async ({ apiContext }) => {
     if (createdRecipeId !== null) {
@@ -12,38 +18,38 @@ test.describe('Create Recipe', () => {
   });
 
   test('should create a new recipe with all fields', async ({ authenticatedPage }) => {
-    // Navigate to create recipe page
     await authenticatedPage.goto('/recipes/create');
 
-    // Fill in recipe details
-    await authenticatedPage.getByLabel(/title/i).fill('E2E Test Recipe');
+    // Step 1: Basic Info
+    await authenticatedPage.getByLabel(/recipe title/i).fill('E2E Test Recipe');
     await authenticatedPage.getByLabel(/description/i).fill('A test recipe created by E2E tests');
+    await authenticatedPage.getByRole('button', { name: /^next$/i }).click();
 
-    // Fill in cooking details
-    await authenticatedPage.getByLabel(/prep time/i).fill('15');
-    await authenticatedPage.getByLabel(/cook time/i).fill('30');
-    await authenticatedPage.getByLabel(/servings/i).fill('4');
+    // Step 2: Ingredients — at least one is required to advance
+    await authenticatedPage.getByLabel(/^ingredient$/i).fill('Flour');
+    await authenticatedPage.getByLabel(/quantity/i).fill('2');
+    await authenticatedPage.getByLabel(/^unit$/i).fill('cups');
+    await authenticatedPage.getByRole('button', { name: /add ingredient/i }).click();
+    await expect(authenticatedPage.getByText('2 cups Flour')).toBeVisible();
+    await authenticatedPage.getByRole('button', { name: /^next$/i }).click();
 
-    // Select difficulty
-    await authenticatedPage.getByLabel(/difficulty/i).click();
-    await authenticatedPage.getByRole('option', { name: /medium/i }).click();
-
-    // Add instructions
+    // Step 3: Instructions — bulk mode is the default
     await authenticatedPage.getByLabel(/instructions/i).fill('1. Prepare ingredients\n2. Cook\n3. Serve');
+    await authenticatedPage.getByRole('button', { name: /apply instructions/i }).click();
+    await authenticatedPage.getByRole('button', { name: /^next$/i }).click();
 
-    // Submit form
+    // Step 4: Review — submit
     await authenticatedPage.getByRole('button', { name: /create recipe/i }).click();
 
-    // Should redirect to recipe detail page
-    await expect(authenticatedPage).toHaveURL(/\/recipes\/\d+/);
+    // Success message renders on this page before the redirect fires
+    await expect(authenticatedPage.getByText(/recipe created successfully/i)).toBeVisible();
+
+    // Should redirect to recipe detail page (recipe ids are UUIDs, not ints)
+    await expect(authenticatedPage).toHaveURL(/\/recipes\/[0-9a-f-]+$/, { timeout: 5000 });
 
     // Capture created recipe ID for cleanup
-    const url = authenticatedPage.url();
-    const match = url.match(/\/recipes\/(\d+)/);
-    if (match) createdRecipeId = parseInt(match[1], 10);
-
-    // Should show success message
-    await expect(authenticatedPage.getByText(/recipe created successfully/i)).toBeVisible();
+    const match = authenticatedPage.url().match(/\/recipes\/([0-9a-f-]+)$/);
+    if (match) createdRecipeId = match[1];
 
     // Should display the recipe details
     await expect(authenticatedPage.getByRole('heading', { name: /e2e test recipe/i })).toBeVisible();
@@ -52,48 +58,55 @@ test.describe('Create Recipe', () => {
   test('should show validation errors for required fields', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/recipes/create');
 
-    // Try to submit without filling required fields
-    await authenticatedPage.getByRole('button', { name: /create recipe/i }).click();
+    // Title is the only required Basic Info field; leave it empty and try
+    // to advance past step 1.
+    await authenticatedPage.getByRole('button', { name: /^next$/i }).click();
 
-    // Should show validation errors
-    await expect(authenticatedPage.getByText(/title is required/i)).toBeVisible();
-    await expect(authenticatedPage.getByText(/description is required/i)).toBeVisible();
+    // Should show validation error and stay on step 1
+    await expect(authenticatedPage.getByText(/recipe title is required/i)).toBeVisible();
+    await expect(authenticatedPage.getByLabel(/recipe title/i)).toBeVisible();
   });
 
   test('should add and remove ingredients', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/recipes/create');
+    await authenticatedPage.getByLabel(/recipe title/i).fill('E2E Ingredients Recipe');
+    await authenticatedPage.getByRole('button', { name: /^next$/i }).click();
 
     // Add first ingredient
+    await authenticatedPage.getByLabel(/^ingredient$/i).fill('Flour');
+    await authenticatedPage.getByLabel(/quantity/i).fill('2');
+    await authenticatedPage.getByLabel(/^unit$/i).fill('cups');
     await authenticatedPage.getByRole('button', { name: /add ingredient/i }).click();
-    await authenticatedPage.getByLabel(/ingredient name/i).first().fill('Flour');
-    await authenticatedPage.getByLabel(/quantity/i).first().fill('2');
-    await authenticatedPage.getByLabel(/unit/i).first().fill('cups');
 
     // Add second ingredient
+    await authenticatedPage.getByLabel(/^ingredient$/i).fill('Sugar');
+    await authenticatedPage.getByLabel(/quantity/i).fill('1');
+    await authenticatedPage.getByLabel(/^unit$/i).fill('cup');
     await authenticatedPage.getByRole('button', { name: /add ingredient/i }).click();
-    await authenticatedPage.getByLabel(/ingredient name/i).last().fill('Sugar');
-    await authenticatedPage.getByLabel(/quantity/i).last().fill('1');
-    await authenticatedPage.getByLabel(/unit/i).last().fill('cup');
 
-    // Should have 2 ingredients
-    const ingredients = authenticatedPage.getByLabel(/ingredient name/i);
-    await expect(ingredients).toHaveCount(2);
+    // Should have 2 ingredients listed
+    await expect(authenticatedPage.getByText('2 cups Flour')).toBeVisible();
+    await expect(authenticatedPage.getByText('1 cup Sugar')).toBeVisible();
+    await expect(authenticatedPage.getByText(/ingredients list \(2\)/i)).toBeVisible();
 
-    // Remove first ingredient
-    await authenticatedPage.getByRole('button', { name: /remove ingredient/i }).first().click();
+    // Remove the first ingredient
+    await authenticatedPage.getByRole('listitem').filter({ hasText: 'Flour' })
+      .getByRole('button').click();
 
-    // Should have 1 ingredient
-    await expect(ingredients).toHaveCount(1);
+    // Should have 1 ingredient left
+    await expect(authenticatedPage.getByText(/ingredients list \(1\)/i)).toBeVisible();
+    await expect(authenticatedPage.getByText('2 cups Flour')).not.toBeVisible();
   });
 
   test('should cancel recipe creation', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/recipes/create');
 
     // Fill in some data
-    await authenticatedPage.getByLabel(/title/i).fill('Test Recipe');
+    await authenticatedPage.getByLabel(/recipe title/i).fill('Test Recipe');
 
-    // Click cancel
-    await authenticatedPage.getByRole('button', { name: /cancel/i }).click();
+    // Click the back link (there is no explicit "Cancel" button — the
+    // wizard uses "Back to Recipes" for this)
+    await authenticatedPage.getByRole('button', { name: /back to recipes/i }).click();
 
     // Should navigate back to recipes list
     await expect(authenticatedPage).toHaveURL('/recipes');

--- a/frontend/e2e/tests/recipes/delete.spec.ts
+++ b/frontend/e2e/tests/recipes/delete.spec.ts
@@ -16,6 +16,15 @@ test.describe('Delete Recipe', () => {
   test('should delete a recipe with confirmation', async ({ authenticatedPage }) => {
     await authenticatedPage.goto(`/recipes/${testRecipe.id}`);
 
+    // The success message is a native alert(), not DOM text — Playwright
+    // auto-dismisses dialogs unless a handler is registered, so capture and
+    // accept it here to both verify the message and let navigation proceed.
+    let dialogMessage = '';
+    authenticatedPage.once('dialog', async (dialog) => {
+      dialogMessage = dialog.message();
+      await dialog.accept();
+    });
+
     // Click delete button
     await authenticatedPage.getByRole('button', { name: /delete/i }).click();
 
@@ -26,10 +35,9 @@ test.describe('Delete Recipe', () => {
     await authenticatedPage.getByRole('button', { name: /confirm|yes|delete/i }).click();
 
     // Should redirect to recipes list
-    await expect(authenticatedPage).toHaveURL('/recipes');
+    await expect(authenticatedPage).toHaveURL('/recipes', { timeout: 5000 });
 
-    // Should show success message
-    await expect(authenticatedPage.getByText(/recipe deleted successfully/i)).toBeVisible();
+    expect(dialogMessage).toMatch(/successfully deleted/i);
   });
 
   test('should cancel recipe deletion', async ({ authenticatedPage }) => {

--- a/frontend/e2e/tests/recipes/edit.spec.ts
+++ b/frontend/e2e/tests/recipes/edit.spec.ts
@@ -1,6 +1,12 @@
 import { test, expect } from '../../fixtures/auth.fixture';
 import { createTestRecipe, deleteTestRecipe, TestRecipe } from '../../helpers/test-data';
 
+// The edit route (/recipes/:id/edit) renders the same 4-step wizard as
+// create (Basic Info -> Ingredients -> Instructions -> Review). The test
+// recipe's seeded ingredient/instruction (see helpers/test-data.ts) already
+// satisfy the Ingredients/Instructions step validation, so editing only
+// needs to touch Basic Info and then click through the remaining steps.
+
 test.describe('Edit Recipe', () => {
   let testRecipe: TestRecipe;
 
@@ -18,27 +24,32 @@ test.describe('Edit Recipe', () => {
     // Click edit button
     await authenticatedPage.getByRole('button', { name: /edit/i }).click();
 
-    // Should navigate to edit page
-    await expect(authenticatedPage).toHaveURL(/\/recipes\/\d+\/edit/);
+    // Should navigate to edit page (recipe ids are UUIDs, not ints)
+    await expect(authenticatedPage).toHaveURL(/\/recipes\/[0-9a-f-]+\/edit/);
 
-    // Update title
-    const titleInput = authenticatedPage.getByLabel(/title/i);
+    // Update title and description on step 1 (Basic Info)
+    const titleInput = authenticatedPage.getByLabel(/recipe title/i);
     await titleInput.clear();
     await titleInput.fill('Updated Recipe Title');
 
-    // Update description
     const descInput = authenticatedPage.getByLabel(/description/i);
     await descInput.clear();
     await descInput.fill('Updated description');
 
+    // The seeded ingredient/instruction already satisfy steps 2 and 3, so
+    // just click through to Review.
+    await authenticatedPage.getByRole('button', { name: /^next$/i }).click();
+    await authenticatedPage.getByRole('button', { name: /^next$/i }).click();
+    await authenticatedPage.getByRole('button', { name: /^next$/i }).click();
+
     // Save changes
-    await authenticatedPage.getByRole('button', { name: /save changes/i }).click();
+    await authenticatedPage.getByRole('button', { name: /update recipe/i }).click();
+
+    // Should show success message before the redirect fires
+    await expect(authenticatedPage.getByText(/recipe updated successfully/i)).toBeVisible();
 
     // Should redirect back to recipe detail
-    await expect(authenticatedPage).toHaveURL(/\/recipes\/\d+$/);
-
-    // Should show success message
-    await expect(authenticatedPage.getByText(/recipe updated successfully/i)).toBeVisible();
+    await expect(authenticatedPage).toHaveURL(`/recipes/${testRecipe.id}`, { timeout: 5000 });
 
     // Should display updated title
     await expect(authenticatedPage.getByRole('heading', { name: /updated recipe title/i })).toBeVisible();
@@ -51,15 +62,17 @@ test.describe('Edit Recipe', () => {
     await authenticatedPage.getByRole('button', { name: /edit/i }).click();
 
     // Make some changes
-    await authenticatedPage.getByLabel(/title/i).fill('Changed Title');
+    await authenticatedPage.getByLabel(/recipe title/i).fill('Changed Title');
 
-    // Click cancel
-    await authenticatedPage.getByRole('button', { name: /cancel/i }).click();
+    // There is no explicit "Cancel" button — the wizard uses "Back to
+    // Recipes", which returns to the recipes list rather than this recipe's
+    // detail page.
+    await authenticatedPage.getByRole('button', { name: /back to recipes/i }).click();
+    await expect(authenticatedPage).toHaveURL('/recipes');
 
-    // Should navigate back to recipe detail
-    await expect(authenticatedPage).toHaveURL(`/recipes/${testRecipe.id}`);
-
-    // Changes should not be saved
+    // Changes should not have been saved
+    await authenticatedPage.goto(`/recipes/${testRecipe.id}`);
+    await expect(authenticatedPage.getByRole('heading', { name: /edit target recipe/i })).toBeVisible();
     await expect(authenticatedPage.getByRole('heading', { name: /changed title/i })).not.toBeVisible();
   });
 
@@ -69,16 +82,15 @@ test.describe('Edit Recipe', () => {
     // Click edit button
     await authenticatedPage.getByRole('button', { name: /edit/i }).click();
 
-    // Clear required fields
-    await authenticatedPage.getByLabel(/title/i).clear();
-    await authenticatedPage.getByLabel(/description/i).clear();
+    // Clear the required title field
+    await authenticatedPage.getByLabel(/recipe title/i).clear();
 
-    // Try to save
-    await authenticatedPage.getByRole('button', { name: /save changes/i }).click();
+    // Try to advance past step 1
+    await authenticatedPage.getByRole('button', { name: /^next$/i }).click();
 
-    // Should show validation errors
-    await expect(authenticatedPage.getByText(/title is required/i)).toBeVisible();
-    await expect(authenticatedPage.getByText(/description is required/i)).toBeVisible();
+    // Should show validation error and stay on step 1
+    await expect(authenticatedPage.getByText(/recipe title is required/i)).toBeVisible();
+    await expect(authenticatedPage.getByLabel(/recipe title/i)).toBeVisible();
   });
 });
 

--- a/frontend/src/pages/BrowseRecipes.tsx
+++ b/frontend/src/pages/BrowseRecipes.tsx
@@ -122,7 +122,7 @@ const BrowseRecipeCard = memo(({ recipe, onAddToBox, onViewDetails, isAdded }: B
         )}
       </Box>
       <CardContent sx={{ flexGrow: 1 }}>
-        <Typography variant="h6" gutterBottom noWrap>
+        <Typography variant="h6" component="h2" gutterBottom noWrap>
           {recipe.title}
         </Typography>
         <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', gap: 1, mb: 1 }}>
@@ -464,6 +464,10 @@ const BrowseRecipes: React.FC = () => {
                   ),
                 },
                 htmlInput: {
+                  // role="combobox" is required for aria-expanded/aria-autocomplete/
+                  // aria-controls to be allowed at all — a plain textbox's implicit
+                  // role doesn't support them (axe: aria-allowed-attr).
+                  role: 'combobox',
                   'aria-label': 'Search recipes with natural language',
                   'aria-describedby': 'search-help-text',
                   'aria-expanded': showSuggestions,
@@ -495,7 +499,9 @@ const BrowseRecipes: React.FC = () => {
             <Badge badgeContent={activeFilterCount} color="primary">
               <FilterListIcon color={hasActiveFilters ? "primary" : "action"} />
             </Badge>
-            <Typography variant="subtitle2" color={hasActiveFilters ? "primary" : "text.secondary"} sx={{ fontWeight: hasActiveFilters ? 600 : 400 }}>
+            {/* MUI defaults subtitle2 to an <h6> tag — this is a section
+                label, not a document heading. */}
+            <Typography variant="subtitle2" component="span" color={hasActiveFilters ? "primary" : "text.secondary"} sx={{ fontWeight: hasActiveFilters ? 600 : 400 }}>
               Filters {hasActiveFilters && `(${activeFilterCount} active)`}
             </Typography>
             {hasActiveFilters && (
@@ -553,8 +559,8 @@ const BrowseRecipes: React.FC = () => {
           
           <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ flexWrap: 'wrap' }}>
             <FormControl sx={{ minWidth: 150 }}>
-              <InputLabel>Cuisine</InputLabel>
-              <Select value={cuisine} label="Cuisine" onChange={(e) => setCuisine(e.target.value)}>
+              <InputLabel id="browse-cuisine-label">Cuisine</InputLabel>
+              <Select labelId="browse-cuisine-label" value={cuisine} label="Cuisine" onChange={(e) => setCuisine(e.target.value)}>
                 <MenuItem value="">All</MenuItem>
                 <MenuItem value="African">African</MenuItem>
                 <MenuItem value="American">American</MenuItem>
@@ -578,8 +584,8 @@ const BrowseRecipes: React.FC = () => {
             </FormControl>
 
             <FormControl sx={{ minWidth: 150 }}>
-              <InputLabel>Diet</InputLabel>
-              <Select value={diet} label="Diet" onChange={(e) => setDiet(e.target.value)}>
+              <InputLabel id="browse-diet-label">Diet</InputLabel>
+              <Select labelId="browse-diet-label" value={diet} label="Diet" onChange={(e) => setDiet(e.target.value)}>
                 <MenuItem value="">All</MenuItem>
                 <MenuItem value="Gluten Free">Gluten Free</MenuItem>
                 <MenuItem value="Ketogenic">Ketogenic</MenuItem>
@@ -593,8 +599,8 @@ const BrowseRecipes: React.FC = () => {
             </FormControl>
 
             <FormControl sx={{ minWidth: 150 }}>
-              <InputLabel>Meal Type</InputLabel>
-              <Select value={mealType} label="Meal Type" onChange={(e) => setMealType(e.target.value)}>
+              <InputLabel id="browse-meal-type-label">Meal Type</InputLabel>
+              <Select labelId="browse-meal-type-label" value={mealType} label="Meal Type" onChange={(e) => setMealType(e.target.value)}>
                 <MenuItem value="">All</MenuItem>
                 <MenuItem value="breakfast">Breakfast</MenuItem>
                 <MenuItem value="lunch">Lunch</MenuItem>
@@ -605,8 +611,8 @@ const BrowseRecipes: React.FC = () => {
             </FormControl>
 
             <FormControl sx={{ minWidth: 180 }}>
-              <InputLabel>Sort By</InputLabel>
-              <Select value={sortBy} label="Sort By" onChange={(e) => setSortBy(e.target.value)}>
+              <InputLabel id="browse-sort-by-label">Sort By</InputLabel>
+              <Select labelId="browse-sort-by-label" value={sortBy} label="Sort By" onChange={(e) => setSortBy(e.target.value)}>
                 <MenuItem value="popularity">Popularity</MenuItem>
                 <MenuItem value="time">Cooking Time</MenuItem>
                 <MenuItem value="healthiness">Healthiness</MenuItem>
@@ -692,7 +698,7 @@ const BrowseRecipes: React.FC = () => {
       {!loading && recipes.length === 0 && (
         <Box sx={{ textAlign: 'center', py: 8 }}>
           <ExploreIcon sx={{ fontSize: 80, color: 'text.secondary', mb: 2 }} />
-          <Typography variant="h6" color="text.secondary" gutterBottom>
+          <Typography variant="h6" component="h2" color="text.secondary" gutterBottom>
             {searchQuery || hasActiveFilters ? 'No recipes found' : 'Start searching to discover recipes'}
           </Typography>
           <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>

--- a/frontend/src/pages/CreateRecipe.tsx
+++ b/frontend/src/pages/CreateRecipe.tsx
@@ -712,7 +712,7 @@ export default function CreateRecipe() {
   const renderIngredients = () => (
     <Box>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-        <Typography variant="h6">
+        <Typography variant="h6" component="h2">
           Add Ingredients
         </Typography>
         <Chip
@@ -815,6 +815,7 @@ export default function CreateRecipe() {
           <IconButton
             color="primary"
             onClick={handleAddIngredient}
+            aria-label="Add ingredient"
             sx={{ mt: 1 }}
           >
             <AddIcon />
@@ -930,7 +931,7 @@ export default function CreateRecipe() {
   const renderInstructions = () => (
     <Box>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-        <Typography variant="h6">
+        <Typography variant="h6" component="h2">
           Cooking Instructions
         </Typography>
         <ToggleButtonGroup
@@ -956,6 +957,7 @@ export default function CreateRecipe() {
             fullWidth
             multiline
             rows={12}
+            label="Instructions"
             value={bulkInstructions}
             onChange={(e) => setBulkInstructions(e.target.value)}
             placeholder="Paste or type instructions here. Each line will become a step.&#10;&#10;Supports:&#10;1. Numbered lists (1. 2. 3.)&#10;• Bullet points&#10;- Dashes&#10;Or plain paragraphs"
@@ -1012,7 +1014,7 @@ export default function CreateRecipe() {
       )}
 
       <Box sx={{ mt: 4 }}>
-        <Typography variant="h6" gutterBottom>
+        <Typography variant="h6" component="h2" gutterBottom>
           Nutrition Information (Optional)
         </Typography>
         <Grid container spacing={2}>
@@ -1083,7 +1085,7 @@ export default function CreateRecipe() {
 
   const renderReview = () => (
     <Box>
-      <Typography variant="h6" gutterBottom>
+      <Typography variant="h6" component="h2" gutterBottom>
         Review Your Recipe
       </Typography>
 
@@ -1184,7 +1186,7 @@ export default function CreateRecipe() {
       </Button>
       
       <Box sx={{ mb: 4 }}>
-        <Typography variant="h4" gutterBottom>
+        <Typography variant="h4" component="h1" gutterBottom>
           {isEditMode ? 'Edit Recipe' : 'Create New Recipe'}
         </Typography>
         <Typography variant="body1" color="text.secondary">

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -55,7 +55,7 @@ const TodayMeals = memo(({ loading, meals, onNavigate }: TodayMealsProps) => {
   if (loading) {
     return (
       <Box>
-        <Typography variant="h6" gutterBottom>Today's Meals</Typography>
+        <Typography variant="h6" component="h2" gutterBottom>Today's Meals</Typography>
         <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
           {MEAL_SLOTS.map((slot) => (
             <Skeleton key={slot} variant="rectangular" width={160} height={56} sx={{ borderRadius: 1 }} />
@@ -68,7 +68,7 @@ const TodayMeals = memo(({ loading, meals, onNavigate }: TodayMealsProps) => {
   return (
     <Box>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
-        <Typography variant="h6">Today's Meals</Typography>
+        <Typography variant="h6" component="h2">Today's Meals</Typography>
         <Button size="small" onClick={onNavigate}>Open Planner</Button>
       </Box>
       <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
@@ -142,7 +142,7 @@ const WeekGlance = memo(({ loading, mealsForWeek, onDayClick }: WeekGlanceProps)
   if (loading) {
     return (
       <Box>
-        <Typography variant="h6" gutterBottom>This Week</Typography>
+        <Typography variant="h6" component="h2" gutterBottom>This Week</Typography>
         <Box sx={{ display: 'flex', gap: 1 }}>
           {days.map((_, i) => <Skeleton key={i} variant="circular" width={36} height={36} />)}
         </Box>
@@ -152,7 +152,7 @@ const WeekGlance = memo(({ loading, mealsForWeek, onDayClick }: WeekGlanceProps)
 
   return (
     <Box>
-      <Typography variant="h6" gutterBottom>This Week</Typography>
+      <Typography variant="h6" component="h2" gutterBottom>This Week</Typography>
       <Box sx={{ display: 'flex', gap: 0.5 }}>
         {days.map((day, i) => {
           const isToday = isSameDay(day, new Date());
@@ -301,7 +301,7 @@ const QuickActionCard = memo(({ title, description, icon, iconColor, ctaLabel, o
     }}
   >
     <Box sx={{ color: iconColor, mb: 1.5 }}>{icon}</Box>
-    <Typography variant="h6" gutterBottom>{title}</Typography>
+    <Typography variant="h6" component="h2" gutterBottom>{title}</Typography>
     <Typography variant="body2" color="text.secondary" sx={{ flexGrow: 1 }}>{description}</Typography>
     <Button
       size="small"
@@ -421,7 +421,7 @@ const Dashboard: React.FC = () => {
           {dataLoading ? (
             <Skeleton variant="text" width={300} height={40} />
           ) : (
-            <Typography variant="h4" gutterBottom>{greeting}</Typography>
+            <Typography variant="h4" component="h1" gutterBottom>{greeting}</Typography>
           )}
           <Typography variant="body1" color="text.secondary">
             Plan your meals, manage your grocery list, and track your pantry.
@@ -490,7 +490,7 @@ const Dashboard: React.FC = () => {
         </Box>
 
         {/* Quick Actions */}
-        <Typography variant="h5" gutterBottom>Quick Actions</Typography>
+        <Typography variant="h5" component="h2" gutterBottom>Quick Actions</Typography>
         <Grid container spacing={3}>
           {quickActions.map((action) => (
             <Grid size={{ xs: 12, sm: 6, md: 3 }} key={action.title}>

--- a/frontend/src/pages/GroceryList.tsx
+++ b/frontend/src/pages/GroceryList.tsx
@@ -50,6 +50,7 @@ import {
 } from '@mui/icons-material';
 import ConfirmDialog from '../components/ConfirmDialog';
 import { useConfirmDialog } from '../hooks/useConfirmDialog';
+import api from '../services/api';
 
 interface Ingredient {
   id: string;
@@ -118,27 +119,15 @@ const GroceryList: React.FC = () => {
   const [openDialog, setOpenDialog] = useState(false);
   const [expandedCategories, setExpandedCategories] = useState<Record<string, boolean>>({});
 
-  const apiBase = import.meta.env.VITE_API_URL || '/api';
-
   const fetchGroceryLists = async () => {
     try {
       setLoading(true);
       setError(null);
-      const token = localStorage.getItem('accessToken');
-      
-      const response = await fetch(`${apiBase}/grocery-lists`, {
-        headers: {
-          'Authorization': `Bearer ${token}`,
-        },
-      });
 
-      if (!response.ok) {
-        throw new Error('Failed to fetch grocery lists');
-      }
-
-      const data = await response.json();
+      const response = await api.get('/grocery-lists');
+      const data = response.data;
       setGroceryLists(data.data || []);
-      
+
       // Set the most recent list as current
       if (data.data && data.data.length > 0) {
         setCurrentList(data.data[0]);
@@ -206,24 +195,11 @@ const GroceryList: React.FC = () => {
       const item = currentList.items.find(i => i.id === itemId);
       if (!item) return;
 
-      const token = localStorage.getItem('accessToken');
-      const response = await fetch(`${apiBase}/grocery-lists/${currentList.id}/items/${itemId}`, {
-        method: 'PUT',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          checked: !item.isChecked,
-        }),
+      const response = await api.put(`/grocery-lists/${currentList.id}/items/${itemId}`, {
+        checked: !item.isChecked,
       });
+      const data = response.data;
 
-      if (!response.ok) {
-        throw new Error('Failed to update item');
-      }
-
-      const data = await response.json();
-      
       // Update local state
       setCurrentList({
         ...currentList,
@@ -248,17 +224,7 @@ const GroceryList: React.FC = () => {
     if (!confirmed) return;
 
     try {
-      const token = localStorage.getItem('accessToken');
-      const response = await fetch(`${apiBase}/grocery-lists/${currentList.id}/items/${itemId}`, {
-        method: 'DELETE',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-        },
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to delete item');
-      }
+      await api.delete(`/grocery-lists/${currentList.id}/items/${itemId}`);
 
       // Update local state
       setCurrentList({
@@ -278,17 +244,10 @@ const GroceryList: React.FC = () => {
     const checkedItems = currentList.items.filter(item => item.isChecked);
     
     try {
-      const token = localStorage.getItem('accessToken');
-      
       // Delete all checked items
       await Promise.all(
         checkedItems.map(item =>
-          fetch(`${apiBase}/grocery-lists/${currentList.id}/items/${item.id}`, {
-            method: 'DELETE',
-            headers: {
-              'Authorization': `Bearer ${token}`,
-            },
-          })
+          api.delete(`/grocery-lists/${currentList.id}/items/${item.id}`)
         )
       );
 
@@ -350,7 +309,7 @@ const GroceryList: React.FC = () => {
       <Box sx={{ mb: 4 }}>
         {/* Header */}
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3, flexWrap: 'wrap', gap: 2 }}>
-          <Typography variant="h4">
+          <Typography variant="h4" component="h1">
             Grocery List
           </Typography>
           <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }}>
@@ -397,7 +356,7 @@ const GroceryList: React.FC = () => {
               <Stack direction="row" spacing={2} sx={{ alignItems: 'center' }}>
                 <ShoppingCartIcon sx={{ fontSize: 40 }} />
                 <Box sx={{ flexGrow: 1 }}>
-                  <Typography variant="h6">
+                  <Typography variant="h6" component="h2">
                     Shopping Progress
                   </Typography>
                   <Typography variant="body2">
@@ -405,7 +364,8 @@ const GroceryList: React.FC = () => {
                   </Typography>
                 </Box>
                 <Box sx={{ textAlign: 'right' }}>
-                  <Typography variant="h4">
+                  {/* Decorative progress readout, not a document heading. */}
+                  <Typography variant="h4" component="div">
                     {Math.round(progress)}%
                   </Typography>
                 </Box>
@@ -419,7 +379,7 @@ const GroceryList: React.FC = () => {
           <Card>
             <CardContent sx={{ textAlign: 'center', py: 8 }}>
               <ShoppingCartIcon sx={{ fontSize: 64, color: 'text.primary', mb: 2 }} aria-hidden="true" />
-              <Typography variant="h6" sx={{ color: 'text.primary' }} gutterBottom>
+              <Typography variant="h6" component="h2" sx={{ color: 'text.primary' }} gutterBottom>
                 Your grocery list is empty
               </Typography>
               <Typography variant="body2" sx={{ mb: 3, color: 'text.primary' }}>
@@ -474,7 +434,7 @@ const GroceryList: React.FC = () => {
                           <CategoryIcon />
                         </Avatar>
                         <Box>
-                          <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                          <Typography variant="h6" component="h2" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                             <span>{categoryConfig.emoji}</span>
                             {categoryConfig.label}
                           </Typography>

--- a/frontend/src/pages/MealPlanner.tsx
+++ b/frontend/src/pages/MealPlanner.tsx
@@ -957,7 +957,7 @@ const MealPlanner: React.FC = () => {
       <Box sx={{ mb: 4 }}>
         {/* Header */}
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
-          <Typography variant="h4">
+          <Typography variant="h4" component="h1">
             Meal Planner
           </Typography>
           <Button
@@ -974,7 +974,9 @@ const MealPlanner: React.FC = () => {
         <Card sx={{ mb: 2, bgcolor: 'background.default' }}>
           <CardContent sx={{ py: 2 }}>
             <Stack spacing={1}>
-              <Typography variant="subtitle2" color="text.secondary" align="center">
+              {/* MUI defaults subtitle2 to an <h6> tag — this is a plain
+                  label, not a document heading. */}
+              <Typography variant="subtitle2" component="span" color="text.secondary" align="center">
                 View Mode
               </Typography>
               <Stack direction="row" spacing={2} sx={{ justifyContent: 'center' }}>
@@ -1014,11 +1016,11 @@ const MealPlanner: React.FC = () => {
         <Card sx={{ mb: 3 }}>
           <CardContent>
             <Stack direction="row" sx={{ alignItems: 'center', justifyContent: 'space-between' }}>
-              <IconButton onClick={handlePreviousWeek}>
+              <IconButton onClick={handlePreviousWeek} aria-label="Previous week">
                 <ChevronLeftIcon />
               </IconButton>
               <Box sx={{ textAlign: 'center' }}>
-                <Typography variant="h6">
+                <Typography variant="h6" component="h2">
                   {format(currentWeekStart, 'MMMM yyyy')}
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
@@ -1034,7 +1036,7 @@ const MealPlanner: React.FC = () => {
                 <Button size="small" onClick={handleToday}>
                   Today
                 </Button>
-                <IconButton onClick={handleNextWeek}>
+                <IconButton onClick={handleNextWeek} aria-label="Next week">
                   <ChevronRightIcon />
                 </IconButton>
               </Stack>
@@ -1087,8 +1089,11 @@ const MealPlanner: React.FC = () => {
                       },
                     }}
                   >
+                    {/* MUI defaults subtitle2 to an <h6> tag — this is a
+                        day-of-week label, not a document heading. */}
                     <Typography
                       variant="subtitle2"
+                      component="span"
                       align="center"
                       gutterBottom
                       sx={{
@@ -1100,6 +1105,7 @@ const MealPlanner: React.FC = () => {
                     </Typography>
                     <Typography
                       variant="h6"
+                      component="h3"
                       align="center"
                       gutterBottom
                       sx={{
@@ -1137,6 +1143,7 @@ const MealPlanner: React.FC = () => {
                             <IconButton
                               size="small"
                               onClick={() => handleOpenDialog(day, mealType)}
+                              aria-label={`Add ${mealType} for ${format(day, 'EEEE')}`}
                             >
                               <AddIcon fontSize="small" />
                             </IconButton>

--- a/frontend/src/pages/Pantry.tsx
+++ b/frontend/src/pages/Pantry.tsx
@@ -292,7 +292,7 @@ const Pantry: React.FC = () => {
       <Box sx={{ mb: 4 }}>
         {/* Header */}
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
-          <Typography variant="h4">
+          <Typography variant="h4" component="h1">
             Pantry Inventory
           </Typography>
           <Button
@@ -337,7 +337,7 @@ const Pantry: React.FC = () => {
           <Card>
             <CardContent sx={{ textAlign: 'center', py: 8 }}>
               <KitchenIcon sx={{ fontSize: 64, color: 'text.secondary', mb: 2 }} />
-              <Typography variant="h6" color="text.secondary" gutterBottom>
+              <Typography variant="h6" component="h2" color="text.secondary" gutterBottom>
                 {activeTab === 0 ? 'Your pantry is empty' : 'No items in this category'}
               </Typography>
               <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -439,7 +439,7 @@ const Profile: React.FC = () => {
   return (
     <Container maxWidth="lg">
       <Box sx={{ mb: 4 }}>
-        <Typography variant="h4" gutterBottom>
+        <Typography variant="h4" component="h1" gutterBottom>
           Profile
         </Typography>
         <Typography variant="body1" color="text.secondary">

--- a/frontend/src/pages/RecipeDetail.tsx
+++ b/frontend/src/pages/RecipeDetail.tsx
@@ -381,7 +381,7 @@ const RecipeDetail: React.FC = () => {
           </Button>
           <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
             <Box>
-              <Typography variant="h3" gutterBottom>
+              <Typography variant="h3" component="h1" gutterBottom>
                 {recipe.title}
               </Typography>
               <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', gap: 1 }}>

--- a/frontend/src/pages/Recipes.tsx
+++ b/frontend/src/pages/Recipes.tsx
@@ -121,7 +121,7 @@ const RecipeCard = memo(({ recipe, onNavigate, onEditIngredients }: RecipeCardPr
         )}
       </Box>
       <CardContent sx={{ flexGrow: 1 }}>
-        <Typography variant="h6" gutterBottom noWrap>{recipe.title}</Typography>
+        <Typography variant="h6" component="h2" gutterBottom noWrap>{recipe.title}</Typography>
         <Typography
           variant="body2"
           color="text.secondary"
@@ -303,7 +303,7 @@ const Recipes: React.FC = () => {
       <Box sx={{ mb: 4 }}>
         {/* Header */}
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
-          <Typography variant="h4">Recipes</Typography>
+          <Typography variant="h4" component="h1">Recipes</Typography>
           <Box sx={{ display: 'flex', gap: 2 }}>
             <Tooltip title="Paste any recipe URL — we'll extract the ingredients and steps automatically." arrow>
               <Button
@@ -320,7 +320,6 @@ const Recipes: React.FC = () => {
                 variant="contained"
                 startIcon={<AddIcon />}
                 onClick={() => navigate('/recipes/create')}
-                aria-label="Create new recipe"
               >
                 Create Recipe
               </Button>
@@ -414,8 +413,9 @@ const Recipes: React.FC = () => {
                 </Tooltip>
               )}
               <FormControl sx={{ minWidth: 180 }}>
-                <InputLabel>Sort By</InputLabel>
+                <InputLabel id="recipes-sort-by-label">Sort By</InputLabel>
                 <Select
+                  labelId="recipes-sort-by-label"
                   value={sortBy}
                   label="Sort By"
                   onChange={(e) => { setSortBy(e.target.value); setCurrentPage(1); }}
@@ -442,8 +442,9 @@ const Recipes: React.FC = () => {
                 sx={{ mt: 2, p: 2, bgcolor: 'background.default', borderRadius: 1 }}
               >
                 <FormControl sx={{ minWidth: 150 }}>
-                  <InputLabel>Difficulty</InputLabel>
+                  <InputLabel id="recipes-difficulty-label">Difficulty</InputLabel>
                   <Select
+                    labelId="recipes-difficulty-label"
                     value={difficulty}
                     label="Difficulty"
                     onChange={(e) => { setDifficulty(e.target.value); setCurrentPage(1); }}
@@ -456,8 +457,9 @@ const Recipes: React.FC = () => {
                 </FormControl>
 
                 <FormControl sx={{ minWidth: 150 }}>
-                  <InputLabel>Meal Type</InputLabel>
+                  <InputLabel id="recipes-meal-type-label">Meal Type</InputLabel>
                   <Select
+                    labelId="recipes-meal-type-label"
                     value={mealType}
                     label="Meal Type"
                     onChange={(e) => { setMealType(e.target.value); setCurrentPage(1); }}
@@ -552,7 +554,7 @@ const Recipes: React.FC = () => {
             ) : (
               <Box sx={{ textAlign: 'center', py: 8 }}>
                 <RestaurantIcon sx={{ fontSize: 64, color: 'text.secondary', mb: 2 }} />
-                <Typography variant="h6" color="text.secondary">No recipes found</Typography>
+                <Typography variant="h6" component="h2" color="text.secondary">No recipes found</Typography>
                 <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
                   Try adjusting your search or filters
                 </Typography>


### PR DESCRIPTION
## Summary

Fixes #341. The e2e suite was failing widely for a mix of reasons — some CI/seed-data gaps, several real app bugs the tests happened to be catching correctly, and a batch of test assumptions that had gone stale relative to the current UI. Full breakdown in the commit message.

**Real app bugs fixed (not just test issues):**
- `GroceryList.tsx` used a hand-rolled `fetch()` reading a `localStorage` key nothing ever sets, sending `Authorization: Bearer null` on every request. This broke the grocery list page (load/toggle/delete/clear-checked) in production, not just in tests. Switched to the shared `api` axios instance.
- Several pages' Typography heading variants had no matching `component`, so the page never actually had a real `<h1>`, and headings skipped levels — genuine WCAG violations axe was correctly catching. Fixed page titles to `<h1>`, normalized section headers, and demoted decorative text (view-mode label, progress %) off the heading tree.
- `BrowseRecipes.tsx`'s filter `<Select>`s never wired `InputLabel`/`Select` `labelId`↔`id`, so the visible label wasn't actually associated with the control for screen readers.
- MealPlanner's week-nav and per-slot "add meal" icon buttons had no accessible name.
- `e2e/mocks/spoonacular.mock.ts`'s two route patterns overlapped, and because Playwright dispatches the most-recently-registered route first, every mocked search request was silently answered by the wrong handler with garbage data — same root cause broke the add-to-box mock (one path segment too narrow), which then hit the real, unconfigured backend and 503'd.

**CI/seed-data gaps:**
- `seed-recipes.ts` existed but was never wired into anything — `pnpm run prisma:seed` now actually seeds it.
- Seeded a `FamilyMember` for the test user — the visual login picker lists `FamilyMember` rows, not `User` rows, so it silently redirected to `/welcome` with none seeded.

**Stale test assumptions**, updated to match current behavior: CreateRecipe is a 4-step wizard (create/edit specs rewritten to drive it); recipe ids are UUIDs not ints; `/login` is the visual picker vs `/login/classic`; three a11y checks pointed at typo'd routes that hit the catch-all redirect and silently re-tested Dashboard; MUI's `ListItemButton` renders `<div role="button">`.

## Test plan
- [x] Full local run of all three Playwright projects (`auth-tests`, `authenticated-tests`, `ftue-audit`) — 70 passed, 1 skipped, 0 failed
- [ ] CI `E2E Tests` workflow green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)