### PR TITLE
Bug smash: grocery list empty state, SPA nav, dead dialog, AppBar title + design docs cleanup

### DIFF
--- a/docs/archive/UIUX_ENHANCEMENTS.md
+++ b/docs/archive/UIUX_ENHANCEMENTS.md
@@ -1,5 +1,9 @@
 # UI/UX Enhancement Backlog
 
+> **Archived 2026-08 (issue #313):** this backlog's only item was fully resolved and
+> converted to GitHub issue #201 (closed) back in 2026-05-16. Moved out of
+> `docs/design/` — which implies an active/open backlog — into `docs/archive/`.
+
 ## Meal Planner - Recipe Selection Modal
 
 ### Enhancement: Smart Recipe Sorting by Meal Occasion

--- a/docs/design/ARIA_ACCESSIBILITY.md
+++ b/docs/design/ARIA_ACCESSIBILITY.md
@@ -4,6 +4,10 @@
 
 This document describes the ARIA labels and semantic HTML implementation for issue #122.
 
+> **Last re-verified:** 2026-08 (issue #313). Line numbers below drift as files change —
+> treat them as approximate pointers, not guarantees. Re-check against the current file
+> before relying on a specific line.
+
 ## Current Status
 
 ### ✅ Components with ARIA Labels
@@ -20,6 +24,9 @@ The following components already have proper ARIA labels:
    - ✅ Refresh button
    - ✅ Clear checked items button
    - ✅ Delete item buttons
+   - ✅ Per-category expand/collapse (the decorative chevron `IconButton` is
+     `aria-hidden` + `tabIndex={-1}`; the accessible name and `aria-expanded`
+     state live on the surrounding clickable `Box`, not the icon itself)
 
 3. **RecipeDetail.tsx**
    - ✅ Servings adjustment buttons
@@ -46,34 +53,40 @@ The following components already have proper ARIA labels:
 
 ### ⚠️ Components Needing ARIA Labels
 
-The following IconButtons need aria-labels added:
+Re-verified 2026-08 against current source. Several items below have already been
+fixed since this list was first written — those moved to the "has ARIA labels"
+section above. The rest are still genuinely missing an accessible name, just at
+updated line numbers.
 
-1. **GroceryList.tsx**
-   - Line 491: Expand/collapse category button (missing aria-label)
+The following IconButtons still need aria-labels added:
 
-2. **AdminDashboard.tsx**
-   - Lines 371-419: All admin action buttons need aria-labels
-     - Edit user button
-     - Block/unblock user buttons
-     - Reset password button
-     - Delete user button
+1. **AdminDashboard.tsx** (~lines 495-543)
+   - Line 495: Edit user role button — has `title="Edit Role"` only; `title` is not
+     a reliable accessible-name source for all screen readers, needs `aria-label`
+   - Line 507: Unblock user button — `title` only, same issue
+   - Line 516: Block user button — `title` only, same issue
+   - Line 525: Reset password button — `title` only, same issue
+   - Line 536: Delete user button — `title` only, same issue
 
-3. **Profile.tsx**
-   - Lines 525-530: Family member edit/delete buttons need aria-labels
+2. **Profile.tsx**
+   - Line 700: Family member edit button (icon-only, no accessible name)
+   - Line 703: Family member delete button (icon-only, no accessible name)
 
-4. **CreateRecipe.tsx**
-   - Line 722: Add ingredient button needs aria-label
-   - Line 747: Remove ingredient buttons need aria-labels
-   - Line 869: Remove instruction button needs aria-label
+3. **CreateRecipe.tsx**
+   - Line 815: Add ingredient button — ✅ already fixed (`aria-label="Add ingredient"`)
+   - Line 870: Remove ingredient button — still icon-only, needs aria-label
+   - Line 993: Remove instruction button — still icon-only, needs aria-label
 
-5. **BatchCookingDialog.tsx**
-   - Line 127: Close dialog button needs aria-label
+4. **BatchCookingDialog.tsx**
+   - Line 127: Close dialog button — still icon-only, needs aria-label (unchanged)
 
-6. **MealPlanner.tsx**
-   - Lines 914, 934: Week navigation buttons need aria-labels
-   - Line 1034: Add meal button needs aria-label
-   - Lines 1233, 1461: Close dialog buttons need aria-labels
-   - Line 1512: Delete meal button needs aria-label
+5. **MealPlanner.tsx**
+   - Line 1019: Previous week button — ✅ already fixed (`aria-label="Previous week"`)
+   - Line 1039: Next week button — ✅ already fixed (`aria-label="Next week"`)
+   - Line 1143: Add meal button — ✅ already fixed (has a dynamic `aria-label`)
+   - Line 1388: Meal-detail dialog close button — still icon-only, needs aria-label
+   - Line 1609: Day-summary dialog close button — still icon-only, needs aria-label
+   - Line 1660: Delete meal button — still icon-only, needs aria-label
 
 ## Implementation Plan
 
@@ -349,7 +362,10 @@ Completed:
 - ✅ Navigation landmarks
 
 Needs Work:
-- ⚠️ Add missing aria-labels to IconButtons
+- ⚠️ Add missing aria-labels to IconButtons — see the re-verified list above
+  (AdminDashboard.tsx action buttons, Profile.tsx family edit/delete, CreateRecipe.tsx
+  remove-ingredient/instruction, BatchCookingDialog.tsx close, MealPlanner.tsx dialog
+  close × 2 and delete-meal)
 - ⚠️ Add ARIA live regions
 - ⚠️ Add aria-current for navigation
 - ⚠️ Screen reader testing required

--- a/docs/design/DESIGN_PRINCIPLES.md
+++ b/docs/design/DESIGN_PRINCIPLES.md
@@ -1,7 +1,7 @@
 # Meal Planner Application - Design Principles
 
-**Version:** 1.1  
-**Last Updated:** 2026-05-16  
+**Version:** 1.2  
+**Last Updated:** 2026-08-03  
 **Status:** Active
 
 ---
@@ -301,7 +301,9 @@ This document establishes the core design principles that guide all user experie
 - Templates for common patterns
 
 **Current Issues:**
-- ❌ Missing: Keyboard shortcuts
+- ✅ Keyboard shortcuts implemented via `useKeyboardShortcuts` (wired into
+  `Layout.tsx`) — see `docs/design/KEYBOARD_NAVIGATION.md`. Note: shortcuts are
+  fully implemented but not yet discoverable in the UI (tracked in #308).
 - ❌ Missing: Recipe templates
 - ❌ Missing: Bulk meal plan creation
 
@@ -442,7 +444,7 @@ This document establishes the core design principles that guide all user experie
 - **Related Documents:**
   - `docs/ARCHITECTURE.md` - Technical architecture
   - `ISSUE_PRIORITIES.md` - Current priorities
-  - `P0_P1_ISSUES_SUMMARY.md` - Recent fixes
+  - `docs/archive/releases/beta-launch/P0_P1_ISSUES_SUMMARY.md` - Recent fixes
 
 ---
 
@@ -477,3 +479,7 @@ Use this checklist when designing new features or evaluating existing ones:
 **Version History:**
 - v1.0 (2026-04-20): Initial creation based on current application state and recent fixes
 - v1.1 (2026-05-16): Marked principles 2, 9, 12, 13, 14 gaps resolved via Epic #191 Visual Refresh. Noted WCAG amber contrast gap.
+- v1.2 (2026-08-03): Issue #313 doc-accuracy pass — corrected Principle 16's stale
+  "keyboard shortcuts missing" claim (implemented since before v1.1; see
+  `docs/design/KEYBOARD_NAVIGATION.md` and issue #308 for the discoverability gap),
+  fixed the broken `P0_P1_ISSUES_SUMMARY.md` reference link.

--- a/docs/design/EPIC_VISUAL_REFRESH.md
+++ b/docs/design/EPIC_VISUAL_REFRESH.md
@@ -316,7 +316,7 @@ Phase 1 and 2 are the 80/20. The color fix and dashboard redesign alone will cha
 - [ ] Issue #25 closed with reference to Child #1
 - [ ] UIUX_ENHANCEMENTS.md smart-sorting item converted to a closed GitHub issue
 - [ ] `DESIGN_PRINCIPLES.md` updated: mark principles 2, 9, 12, 13, 14 gaps as resolved where applicable
-- [ ] `../archive/DESIGN_EVALUATION_CHECKLIST.md` re-evaluated against final state
+- [ ] `../archive/design-reviews/DESIGN_EVALUATION_CHECKLIST.md` re-evaluated against final state
 - [ ] No WCAG AA regressions (run contrast audit on any changed palette values)
 - [ ] `ISSUE_PRIORITIES.md` updated to reflect new child issues and closed #25
 
@@ -326,10 +326,10 @@ Phase 1 and 2 are the 80/20. The color fix and dashboard redesign alone will cha
 
 - `DESIGN_PRINCIPLES.md` — establishes the principles this epic addresses
 - `../DESIGN_UX_EVALUATION_REPORT.md` — internal B- grade evaluation (2026-04-20)
-- `docs/DESIGN_CONSULTANCY_REVIEW.md` — external C+ grade evaluation (2026-04-21)
-- `docs/DESIGN_REVIEW_COMPARISON.md` — resolution of disagreements between the two reviews
-- `docs/DESIGN_EVALUATION_CHECKLIST.md` — beta launch readiness checklist
-- `UIUX_ENHANCEMENTS.md` — smart recipe sorting backlog item (absorbed into Child #6)
+- `../archive/design-reviews/DESIGN_CONSULTANCY_REVIEW.md` — external C+ grade evaluation (2026-04-21)
+- `../archive/design-reviews/DESIGN_REVIEW_COMPARISON.md` — resolution of disagreements between the two reviews
+- `../archive/design-reviews/DESIGN_EVALUATION_CHECKLIST.md` — beta launch readiness checklist
+- `../archive/UIUX_ENHANCEMENTS.md` — smart recipe sorting backlog item (absorbed into Child #6; archived — item shipped as issue #201, closed)
 - `frontend/src/theme.ts` — MUI theme (target of Child #2, #3, #11)
 - `frontend/src/pages/Dashboard.tsx` — target of Child #1, #8
 - `frontend/src/pages/Recipes.tsx` — target of Child #6, #7

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -11,7 +11,7 @@ This directory contains all design, accessibility, and user experience documenta
 - **Check accessibility**: See [ARIA Accessibility](ARIA_ACCESSIBILITY.md)
 - **Verify WCAG compliance**: See [WCAG Compliance](WCAG_COMPLIANCE.md)
 - **Implement keyboard navigation**: See [Keyboard Navigation](KEYBOARD_NAVIGATION.md)
-- **Plan UI enhancements**: See [UI/UX Enhancements](UIUX_ENHANCEMENTS.md)
+- **Plan UI enhancements**: See [UI/UX Enhancements](../archive/UIUX_ENHANCEMENTS.md) (archived — its one item shipped as #201)
 
 ## Documentation Files
 
@@ -86,15 +86,10 @@ Comprehensive keyboard navigation support:
 - `Esc` - Close modals/dialogs
 - `Arrow keys` - Navigate lists/menus
 
-### [UI/UX Enhancements](UIUX_ENHANCEMENTS.md)
-Planned and implemented UI/UX improvements:
-- User feedback and iterations
-- Design system evolution
-- Component improvements
-- Interaction patterns
-- Visual refinements
-- Performance optimizations
-- Mobile experience enhancements
+### [UI/UX Enhancements](../archive/UIUX_ENHANCEMENTS.md) (archived)
+This backlog's one item (smart recipe sorting by meal occasion) shipped as issue #201
+and the doc has been moved to `docs/archive/` accordingly — it no longer represents an
+active backlog.
 
 ### [Epic Visual Refresh](EPIC_VISUAL_REFRESH.md)
 Major visual redesign documentation:

--- a/docs/design/WCAG_COMPLIANCE.md
+++ b/docs/design/WCAG_COMPLIANCE.md
@@ -4,6 +4,14 @@
 
 This document describes the WCAG 2.1 Level AA accessibility compliance implementation for issue #123.
 
+> **Regenerated 2026-08 (issue #313)** against the current `frontend/src/theme.ts` (post
+> Epic #191 Child #2 — the light-theme palette changed since this doc was first written).
+> Ratios below were computed with the same relative-luminance formula as
+> `frontend/src/utils/contrastChecker.ts`, applied to the theme's actual current hex
+> values (note: `contrastChecker.ts`'s own `verifyThemeContrast()` still hardcodes a
+> different, older set of colors than `theme.ts` — that's a separate drift worth a
+> follow-up issue, tracked outside this doc pass).
+
 ## Color Contrast Verification
 
 ### WCAG 2.1 Requirements
@@ -14,60 +22,59 @@ This document describes the WCAG 2.1 Level AA accessibility compliance implement
 - UI components and graphics: 3:1 minimum contrast ratio
 - Focus indicators: 3:1 minimum contrast ratio
 
-### Theme Color Analysis
+### Theme Color Analysis (Light Mode)
 
 #### Primary Colors
 - **Primary Main (#2E7D32 on #FFFFFF)**
-  - Contrast Ratio: 5.32:1
+  - Contrast Ratio: 5.13:1
   - Status: ✅ PASSES AA (4.5:1 required)
-  - Status: ✅ PASSES AAA (7:1 required for normal text)
+  - Status: ❌ FAILS AAA (7:1 required for normal text)
 
-- **Primary Dark (#005005 on #FFFFFF)**
-  - Contrast Ratio: 10.42:1
+- **Primary Dark (#1B5E20 on #FFFFFF)**
+  - Contrast Ratio: 7.87:1
   - Status: ✅ PASSES AA
   - Status: ✅ PASSES AAA
 
-- **Primary Light (#60AD5E on #FFFFFF)**
-  - Contrast Ratio: 3.12:1
-  - Status: ✅ PASSES AA for large text (3:1 required)
-  - Status: ⚠️ Use only for large text or non-text elements
+- **Primary Light (#60A46A on #FFFFFF)**
+  - Contrast Ratio: 2.99:1
+  - Status: ❌ FAILS AA even for large text (3:1 required)
+  - Status: ⚠️ Use only for non-text/decorative elements
 
 #### Secondary Colors
-- **Secondary Main (#FF6F00 on #FFFFFF)**
-  - Contrast Ratio: 3.95:1
-  - Status: ⚠️ BORDERLINE - Use for large text only
-  - Recommendation: Use secondary.dark for normal text
+- **Secondary Main (#D4880C on #FFFFFF)**
+  - Contrast Ratio: 2.87:1
+  - Status: ❌ FAILS AA, including for large text
+  - Recommendation: Use secondary.dark for any text usage
 
-- **Secondary Dark (#C43E00 on #FFFFFF)**
-  - Contrast Ratio: 6.21:1
-  - Status: ✅ PASSES AA
-  - Status: ✅ PASSES AAA
+- **Secondary Dark (#B36B00 on #FFFFFF)**
+  - Contrast Ratio: 4.18:1
+  - Status: ⚠️ PASSES AA for large text only (3:1) — FAILS normal text (4.5:1)
 
-- **Secondary Light (#FFA040 on #FFFFFF)**
-  - Contrast Ratio: 2.51:1
-  - Status: ❌ FAILS AA for normal text
-  - Status: ⚠️ Use only for decorative elements or large text
+- **Secondary Light (#E6A020 on #FFFFFF)**
+  - Contrast Ratio: 2.23:1
+  - Status: ❌ FAILS AA for normal and large text
+  - Status: ⚠️ Decorative / non-text use only
 
 #### Status Colors
 - **Error (#D32F2F on #FFFFFF)**
-  - Contrast Ratio: 5.52:1
+  - Contrast Ratio: 4.98:1
   - Status: ✅ PASSES AA
 
-- **Warning (#F57C00 on #FFFFFF)**
-  - Contrast Ratio: 3.96:1
-  - Status: ⚠️ BORDERLINE - Use for large text
+- **Warning (#D4880C on #FFFFFF)** — same hex as secondary.main in light mode
+  - Contrast Ratio: 2.87:1
+  - Status: ❌ FAILS AA, including for large text
 
-- **Info (#0288D1 on #FFFFFF)**
-  - Contrast Ratio: 4.51:1
+- **Info (#0277BD on #FFFFFF)**
+  - Contrast Ratio: 4.80:1
   - Status: ✅ PASSES AA
 
-- **Success (#388E3C on #FFFFFF)**
-  - Contrast Ratio: 4.68:1
+- **Success (#2E7D32 on #FFFFFF)** — same hex as primary.main
+  - Contrast Ratio: 5.13:1
   - Status: ✅ PASSES AA
 
 #### Background Colors
 - **Text on Default Background (#000000 on #F5F5F5)**
-  - Contrast Ratio: 19.58:1
+  - Contrast Ratio: 19.26:1
   - Status: ✅ PASSES AA
   - Status: ✅ PASSES AAA
 
@@ -75,6 +82,29 @@ This document describes the WCAG 2.1 Level AA accessibility compliance implement
   - Contrast Ratio: 21:1
   - Status: ✅ PASSES AA
   - Status: ✅ PASSES AAA
+
+### Theme Color Analysis (Dark Mode, on #121212)
+
+Dark mode uses a separate, lighter palette rather than the light-mode colors inverted —
+all three checked pass comfortably:
+
+- **Primary Main (#66BB6A on #121212)** — 7.92:1 — ✅ PASSES AA and AAA
+- **Secondary Main (#FFB74D on #121212)** — 10.82:1 — ✅ PASSES AA and AAA
+- **Info Main (#4FC3F7 on #121212)** — 9.35:1 — ✅ PASSES AA and AAA
+
+### ⚠️ Action Needed
+
+Unlike the doc's previous revision, several current light-mode colors genuinely fail
+AA at their default weight:
+- `secondary.main` / `warning.main` (#D4880C) fails even the large-text threshold —
+  currently only safe for non-text UI accents, not for any text or icon meant to
+  convey meaning on its own.
+- `secondary.light` (#E6A020) and `primary.light` (#60A46A) are decorative-only.
+- `secondary.dark` (#B36B00) is large-text-safe but not normal-text-safe.
+
+This is a real, current gap — not just a documentation staleness issue — and is worth
+its own follow-up issue if these colors are used for user-facing text rather than
+purely decorative accents. Grep usages before assuming any given occurrence is safe.
 
 ## Implementation
 
@@ -95,24 +125,23 @@ import { meetsWCAG_AA, getContrastRatio } from './utils/contrastChecker';
 
 // Check if colors meet WCAG AA
 const result = meetsWCAG_AA('#2E7D32', '#FFFFFF');
-console.log(result); // { passes: true, ratio: 5.32, required: 4.5 }
+console.log(result); // { passes: true, ratio: 5.13, required: 4.5 }
 
 // Get contrast ratio
-const ratio = getContrastRatio('#FF6F00', '#FFFFFF');
-console.log(ratio); // 3.95
+const ratio = getContrastRatio('#D4880C', '#FFFFFF');
+console.log(ratio); // 2.87
 ```
 
 ### Automatic Verification
 
-The contrast checker runs automatically in development mode and logs results to the console:
-
-```
-🎨 WCAG Contrast Verification
-✅ primary.main: 5.32:1 (required: 4.5:1)
-✅ primary.dark: 10.42:1 (required: 4.5:1)
-⚠️ primary.light: 3.12:1 (required: 4.5:1)
-...
-```
+The contrast checker's `logContrastResults()` runs automatically in development mode
+and logs results to the console — **but note `verifyThemeContrast()`'s hardcoded color
+list has drifted from `theme.ts` and currently checks different hex values than the
+theme actually uses** (e.g. it checks secondary.main against `#C62828`, which appears
+nowhere in `theme.ts`). Treat its console output as unreliable until that function is
+updated to import from `theme.ts` directly rather than hardcoding its own copies. The
+ratios in this document were computed against the theme's real values instead — see
+the sections above.
 
 ## Recommendations
 
@@ -121,35 +150,33 @@ The contrast checker runs automatically in development mode and logs results to 
 1. **Primary Colors**
    - ✅ Use primary.main for all text sizes
    - ✅ Use primary.dark for all text sizes
-   - ⚠️ Use primary.light only for large text (≥18pt)
+   - ❌ Do not use primary.light for text — decorative/non-text only
 
 2. **Secondary Colors**
-   - ⚠️ Use secondary.main only for large text
-   - ✅ Use secondary.dark for all text sizes
+   - ❌ Do not use secondary.main for text (fails even large-text AA) — decorative/non-text only
+   - ⚠️ Use secondary.dark for large text only, not normal text
    - ❌ Avoid secondary.light for text
 
 3. **Status Colors**
    - ✅ Error, Info, Success: Safe for all text
-   - ⚠️ Warning: Use for large text or with darker variant
+   - ❌ Warning (#D4880C): fails even large-text AA — do not use for text; use error or secondary.dark instead if a warning needs to be readable as text
 
 4. **Backgrounds**
    - ✅ All background combinations meet AAA standards
 
 ### Theme Improvements
 
-If stricter compliance is needed, consider these adjustments:
+The light-mode `secondary`/`warning` colors below AA at their current values. If
+stricter compliance is needed, consider adjustments in this range (verify with
+`getContrastRatio` before adopting — these are illustrative starting points, not
+pre-verified final values):
 
 ```typescript
-// Improved secondary color for better contrast
+// Example darker secondary/warning direction — verify actual ratio before using
 secondary: {
-  main: '#E65100', // 4.51:1 - PASSES AA
-  light: '#FF8A50', // Use for large text only
-  dark: '#AC1900', // 7.12:1 - PASSES AAA
-}
-
-// Improved warning color
-warning: {
-  main: '#E65100', // 4.51:1 - PASSES AA
+  main: '#B36B00', // current secondary.dark — 4.18:1, large-text AA only
+  light: '#D4880C', // current secondary.main — still fails AA, decorative only
+  dark: '#8A5400', // darker still — recompute ratio before adopting
 }
 ```
 
@@ -237,9 +264,13 @@ Verify:
 ## WCAG 2.1 AA Compliance Status
 
 ### Color Contrast (1.4.3)
-- Status: ✅ COMPLIANT
-- Notes: All primary text colors meet 4.5:1 ratio
-- Action: Use recommended color variants
+- Status: ⚠️ PARTIAL — primary/error/info/success text colors meet 4.5:1, but the
+  current `secondary`/`warning` palette (#D4880C family) does not, per the
+  re-verified table above
+- Notes: Confirm no user-facing text or meaningful icon relies on secondary.main,
+  secondary.light, or warning.main as its sole color signal
+- Action: Either restrict those colors to decorative/non-text use, or adjust the
+  palette (see Theme Improvements above) and re-run this check
 
 ### Focus Visible (2.4.7)
 - Status: ✅ COMPLIANT (Material-UI default)
@@ -274,22 +305,29 @@ Accessibility features work on:
 
 **Issue #123: [P2][A11Y] Verify Color Contrast and WCAG Compliance**
 
-Status: ✅ Complete
+Status: ⚠️ Re-opened by re-verification (issue #313, 2026-08) — original "Complete"
+status was based on ratios for a color palette the theme no longer uses.
 
 Completed:
-- ✅ Color contrast ratios verified
-- ✅ WCAG AA compliance confirmed
-- ✅ Contrast checker utility created
+- ✅ Contrast checker utility created (`getContrastRatio`/`meetsWCAG_AA` — the
+  functions themselves are correct; only `verifyThemeContrast()`'s hardcoded
+  color list has drifted from `theme.ts`)
 - ✅ Development logging implemented
-- ✅ Documentation created
-- ✅ Usage guidelines provided
+- ✅ Documentation regenerated against current theme (this pass)
+- ✅ Usage guidelines updated
 
-Testing Required:
+Still needed:
+- ⚠️ Decide whether `secondary`/`warning` (#D4880C family) need a palette
+  adjustment, or a policy that they're decorative-only
+- ⚠️ Update `verifyThemeContrast()` in `contrastChecker.ts` to read from
+  `theme.ts` instead of its own hardcoded (and now-wrong) color copies
 - 🧪 Lighthouse audit (manual)
 - 🧪 axe DevTools scan (manual)
 - 🧪 Color blindness testing (manual)
 - 🧪 Zoom testing (manual)
 
-The application's color scheme meets WCAG 2.1 Level AA standards for color contrast. Minor adjustments recommended for secondary.light usage.
+The application's primary/error/info/success colors meet WCAG 2.1 Level AA for color
+contrast. The secondary/warning palette currently does not, and needs either a
+palette change or a decorative-only usage policy — see "Action Needed" above.
 
 ## Made with Bob

--- a/frontend/e2e/tests/grocery/empty-state.spec.ts
+++ b/frontend/e2e/tests/grocery/empty-state.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2026 e2kd7n
+ * All rights reserved.
+ */
+
+import { test, expect } from '../../fixtures/auth.fixture';
+
+// Regression coverage for #303 (error banner shown instead of empty state
+// when the user has no grocery list yet) and #312 (empty-state CTA did a
+// full page reload instead of an SPA transition).
+test.describe('Grocery List — empty state', () => {
+  test('shows the empty state, not an error banner, when no list exists', async ({ authenticatedPage }) => {
+    await authenticatedPage.route('**/api/grocery-lists*', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: [] }),
+      });
+    });
+
+    await authenticatedPage.goto('/grocery-list');
+
+    await expect(authenticatedPage.getByText('Your grocery list is empty')).toBeVisible();
+    await expect(authenticatedPage.getByText(/failed to load grocery lists/i)).not.toBeVisible();
+  });
+
+  test('empty-state CTA navigates via SPA routing, not a full page reload', async ({ authenticatedPage }) => {
+    await authenticatedPage.route('**/api/grocery-lists*', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: [] }),
+      });
+    });
+
+    await authenticatedPage.goto('/grocery-list');
+    await expect(authenticatedPage.getByText('Your grocery list is empty')).toBeVisible();
+
+    // window.location.href tears down and recreates the document, which wipes
+    // the JS heap; react-router's pushState-based navigation does not. Stamp a
+    // marker on window and confirm it survives the click — a full reload would
+    // wipe it, an SPA transition preserves it.
+    await authenticatedPage.evaluate(() => {
+      (window as unknown as { __navMarker: string }).__navMarker = 'still-here';
+    });
+
+    await authenticatedPage.getByRole('button', { name: 'Go to Meal Planner' }).click();
+    await expect(authenticatedPage).toHaveURL(/\/meal-planner$/);
+
+    const markerSurvived = await authenticatedPage.evaluate(
+      () => (window as unknown as { __navMarker?: string }).__navMarker === 'still-here'
+    );
+    expect(markerSurvived).toBe(true);
+  });
+});
+
+// Made with Bob

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -88,6 +88,12 @@ const menuItems = [
   { text: 'Admin', icon: <AdminIcon />, path: '/admin', adminOnly: true },
 ];
 
+// Routes reachable outside the sidebar (avatar dropdown) still need a page title.
+const pageTitles: Record<string, string> = {
+  '/profile': 'Profile',
+  '/admin': 'Admin',
+};
+
 const Layout: React.FC = () => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
@@ -273,7 +279,9 @@ const Layout: React.FC = () => {
             <MenuIcon />
           </IconButton>
           <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1 }}>
-            {menuItems.find((item) => item.path === location.pathname)?.text || drawerTitle}
+            {menuItems.find((item) => item.path === location.pathname)?.text
+              || pageTitles[location.pathname]
+              || drawerTitle}
           </Typography>
           <Tooltip
             title={

--- a/frontend/src/pages/GroceryList.tsx
+++ b/frontend/src/pages/GroceryList.tsx
@@ -5,6 +5,7 @@
 
 
 import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   Container,
   Typography,
@@ -22,10 +23,6 @@ import {
   Chip,
   Divider,
   Stack,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
   CircularProgress,
   Alert,
   Collapse,
@@ -111,12 +108,12 @@ const mapIngredientCategoryToStore = (ingredientCategory: string): string => {
 };
 
 const GroceryList: React.FC = () => {
+  const navigate = useNavigate();
   const { confirm, confirmDialogProps } = useConfirmDialog();
   const [, setGroceryLists] = useState<GroceryList[]>([]);
   const [currentList, setCurrentList] = useState<GroceryList | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [openDialog, setOpenDialog] = useState(false);
   const [expandedCategories, setExpandedCategories] = useState<Record<string, boolean>>({});
 
   const fetchGroceryLists = async () => {
@@ -387,7 +384,7 @@ const GroceryList: React.FC = () => {
               </Typography>
               <Button
                 variant="contained"
-                onClick={() => window.location.href = '/meal-planner'}
+                onClick={() => navigate('/meal-planner')}
               >
                 Go to Meal Planner
               </Button>
@@ -524,18 +521,6 @@ const GroceryList: React.FC = () => {
           </Box>)
         )}
       </Box>
-      {/* Add Item Dialog (Disabled for now) */}
-      <Dialog open={openDialog} onClose={() => setOpenDialog(false)} maxWidth="sm" fullWidth>
-        <DialogTitle>Add Grocery Item</DialogTitle>
-        <DialogContent>
-          <Alert severity="info" sx={{ mt: 1 }}>
-            Adding custom items is not yet supported. Please generate grocery lists from your meal plans.
-          </Alert>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setOpenDialog(false)}>Close</Button>
-        </DialogActions>
-      </Dialog>
       <ConfirmDialog {...confirmDialogProps} />
     </Container>
   );


### PR DESCRIPTION
## Summary

Bug smash session covering the P3 backlog: #303, #301, #312, #310, then #313 (docs, done last per request).

**Code fixes** (`645c5b3`):
- **#303** — Grocery List showed an error banner instead of an empty state for users with no list yet. Root cause was a bad `Authorization: Bearer null` header from a hand-rolled `fetch()`, already fixed upstream in #350's switch to the shared `api` axios instance. Confirmed the empty-state render logic itself was already correct; added e2e regression coverage so this doesn't silently regress.
- **#301** — AppBar page title fell back to the brand name on `/profile` (and would have on `/admin` if it weren't already in the sidebar) because the title lookup only checked the sidebar `menuItems` array. Added a small `pageTitles` map for routes reachable only via the avatar dropdown.
- **#312** — Grocery List empty-state "Go to Meal Planner" button used `window.location.href` instead of `navigate()`, causing a full page reload instead of an SPA transition.
- **#310** — Removed the permanently-unreachable "Add Grocery Item" dialog and its dead `openDialog` state — nothing in the file ever set it to `true`.

**Docs fixes** (`0080555`), done last as requested:
- **#313** — Regenerated `WCAG_COMPLIANCE.md`'s entire contrast table against the current `theme.ts` (colors changed since Epic #191 Child #2). Flagged that the current secondary/warning palette genuinely fails WCAG AA at several weights — a real gap, not just doc drift — and that `contrastChecker.ts`'s own `verifyThemeContrast()` has a separately-stale hardcoded color list.
- Re-verified every claim in `ARIA_ACCESSIBILITY.md`'s "needs ARIA labels" list against current line numbers — several were already fixed and moved to the "has ARIA" list, the rest updated with current line numbers.
- Fixed `DESIGN_PRINCIPLES.md`'s stale "keyboard shortcuts missing" claim (implemented since before the doc's last update) and its broken `P0_P1_ISSUES_SUMMARY.md` link.
- Moved `UIUX_ENHANCEMENTS.md` to `docs/archive/` (its one item shipped as closed issue #201) and fixed the two inbound links in `docs/design/README.md`.
- Fixed `EPIC_VISUAL_REFRESH.md`'s broken relative links to the three docs now living under `docs/archive/design-reviews/`.

## Verification

- Frontend: `tsc -b && vite build` clean, `eslint` clean (0 errors, only pre-existing unrelated warnings).
- Backend: `tsc` clean (unaffected, verified for safety).
- Ran the full local dev stack (Postgres container + backend + frontend) and the complete `authenticated-tests` Playwright project end-to-end: **43 passed, 1 skipped, 0 failed** — including the new grocery empty-state regression test and existing a11y checks on the grocery-list and profile pages.
- Manually verified the AppBar title fix with a targeted Playwright check (`/profile` shows "Profile", not the brand name).
- Along the way, deployed the #341/#351 fixes to the Pi and confirmed the site serves healthy (200 on `/`, CSRF token issued) before starting this work, per this session's earlier gate.

## Test plan

- [x] `#303` — fresh/no-list account shows empty state, not error banner (e2e)
- [x] `#301` — `/profile` AppBar shows "Profile" (e2e)
- [x] `#312` — empty-state CTA navigates via SPA routing, JS heap survives (e2e)
- [x] `#310` — dead dialog code removed, grocery list page still renders/passes a11y checks
- [x] `#313` — doc content re-verified against current code, broken links fixed

Fixes #303, #301, #312, #310, #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)