### PR TITLE
fix(deploy): move --optimize-for-size out of NODE_OPTIONS, add systemd crash-loop circuit breaker

### DIFF
--- a/scripts/pi-run.sh
+++ b/scripts/pi-run.sh
@@ -128,7 +128,7 @@ REDIS_PASSWORD=$(cat secrets/redis_password.txt)
 JWT_SECRET=$(cat secrets/jwt_secret.txt)
 JWT_REFRESH_SECRET=$(cat secrets/jwt_refresh_secret.txt)
 SESSION_SECRET=$(cat secrets/session_secret.txt)
-NODE_OPTIONS=--max-old-space-size=128 --optimize-for-size
+NODE_OPTIONS=--max-old-space-size=128
 EOF
     rsync -az "$tmp_env" "${ZERO_USER}@${ip}:/opt/mealplanner/.env"
     ssh $ssh_opts "${ZERO_USER}@${ip}" 'chmod 600 /opt/mealplanner/.env'
@@ -141,12 +141,21 @@ EOF
 [Unit]
 Description=Meal Planner Backend
 After=network.target
+# Circuit breaker: give up after 10 restarts in 10 minutes instead of
+# crash-looping indefinitely (previously ran 40k-76k restarts unbounded
+# before anyone noticed — see #281 and the NODE_OPTIONS follow-up bug).
+# `systemctl reset-failed mealplanner` clears the counter after a real fix.
+StartLimitIntervalSec=600
+StartLimitBurst=10
 
 [Service]
 Type=simple
 WorkingDirectory=/opt/mealplanner
 EnvironmentFile=/opt/mealplanner/.env
-ExecStart=/usr/local/bin/node dist/index.js
+# --optimize-for-size must be a direct node flag, not NODE_OPTIONS — Node's
+# NODE_OPTIONS allowlist rejects it (exit code 9) even though it's valid
+# on the command line.
+ExecStart=/usr/local/bin/node --optimize-for-size dist/index.js
 Restart=always
 RestartSec=10
 StandardOutput=journal


### PR DESCRIPTION
## Summary
Fixes #353 — all 4 Zero W nodes crash-looping (exit code 9) because `NODE_OPTIONS` rejects `--optimize-for-size`, even though it's valid as a direct CLI flag (confirmed via SSH against real hardware).

- Move `--optimize-for-size` from `.env`'s `NODE_OPTIONS` to the systemd unit's `ExecStart` line directly.
- Add `StartLimitIntervalSec=600` / `StartLimitBurst=10` to the unit's `[Unit]` section — a circuit breaker so a bad deploy gives up after 10 restarts in 10 minutes instead of restarting indefinitely. Both this incident and #281 ran 40k-76k restarts before anyone noticed.

## Test plan
- [x] `bash -n scripts/pi-run.sh` — syntax check passes
- [x] Confirmed via SSH on a live Zero W that `node --optimize-for-size -e "console.log(1)"` exits 0 on the command line (vs. exit 9 via `NODE_OPTIONS`)
- [ ] Redeploy to the cluster and confirm `systemctl is-active mealplanner` stays `active` (not `activating`) and `NRestarts` stops climbing
- [ ] Confirm `curl http://172.19.181.{1,2,3,4}:3001/health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)