### PR TITLE
fix(deploy): don't let a clean Zero W deploy trip set -e on its own success check

### DIFF
--- a/scripts/pi-run.sh
+++ b/scripts/pi-run.sh
@@ -94,19 +94,30 @@ deploy_to_zero() {
         'command -v pnpm >/dev/null 2>&1 || (sudo corepack enable && sudo corepack prepare pnpm@11.1.2 --activate)'
 
     # Install deps directly on the Zero W so pnpm fetches the correct armhf
-    # native binaries (Prisma engine, etc.). Deliberately NOT --prod: the
-    # "prisma" CLI itself is a devDependency, and the root postinstall hook
-    # (prisma generate) needs it present to produce the armv6l query engine.
-    # Also deliberately not followed by `pnpm prune --prod` — pruning is
-    # known to wipe the generated .prisma/client as a side effect (see
-    # backend/Dockerfile's production-stage comment on the same issue),
-    # which would just reintroduce a manual regenerate step. `set -o
-    # pipefail` ensures a failed install actually fails this SSH command
-    # (and thus the script's `set -e`) instead of the exit status coming
-    # from `tail` — see #288.
+    # native binaries where genuinely needed. --ignore-scripts skips every
+    # package's postinstall, including this project's own root-level
+    # "prisma generate" hook (added for #284) — prisma generate cannot run
+    # on this architecture at all: Prisma has no published schema-engine
+    # binary for 32-bit ARMv6 (confirmed 404 from binaries.prisma.sh for
+    # every OpenSSL variant, see #281). The generated client is produced
+    # once on the Pi 4B (arm64, a supported architecture) in deploy_zeros()
+    # and rsynced in below instead. `set -o pipefail` ensures a failed
+    # install actually fails this SSH command (and thus the script's
+    # `set -e`) instead of the exit status coming from `tail` — see #288.
     echo -e "    ${YELLOW}Installing deps on p${slot} (slow on first run)...${NC}"
     ssh $ssh_opts "${ZERO_USER}@${ip}" \
-        'set -o pipefail; cd /opt/mealplanner && pnpm install --frozen-lockfile 2>&1 | tail -5'
+        'set -o pipefail; cd /opt/mealplanner && pnpm install --frozen-lockfile --ignore-scripts 2>&1 | tail -5'
+
+    # Copy the pre-generated Prisma client instead of running `prisma
+    # generate` on this architecture (see comment above and #281). It's
+    # pure JS/WASM (driver-adapter + engineType="client"), so the artifact
+    # generated on the Pi 4B's arm64 host is portable as-is — WASM bytecode
+    # isn't compiled per-host-CPU at generate time, only JIT'd by V8 at
+    # runtime on whatever machine loads it.
+    echo -e "    Syncing pre-generated Prisma client to p${slot}..."
+    rsync -az --delete \
+        "backend/node_modules/${PRISMA_PNPM_DIR}/" \
+        "${ZERO_USER}@${ip}:/opt/mealplanner/node_modules/${PRISMA_PNPM_DIR}/"
 
     # Write .env via a local temp file so secrets never appear in argv/SSH args
     local tmp_env
@@ -172,18 +183,70 @@ UNITEOF
          && sudo systemctl enable mealplanner \
          && sudo systemctl restart mealplanner'
 
-    sleep 3
-    if ssh $ssh_opts "${ZERO_USER}@${ip}" 'systemctl is-active --quiet mealplanner' 2>/dev/null; then
-        echo -e "    ${GREEN}✓ p${slot} backend running${NC}"
+    # Real startup on this hardware takes ~100s (loading node_modules, Prisma
+    # client, DB connection, etc. on constrained ARMv6) — poll instead of a
+    # single early check, which would misreport a healthy-but-slow start as
+    # failed.
+    echo -e "    Waiting for p${slot} to become healthy (can take ~2 minutes)..."
+    local waited=0
+    local healthy=false
+    while [ "$waited" -lt 150 ]; do
+        if ssh $ssh_opts "${ZERO_USER}@${ip}" \
+                'curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://127.0.0.1:3001/health' \
+                2>/dev/null | grep -q "200"; then
+            healthy=true
+            break
+        fi
+        sleep 5
+        waited=$((waited + 5))
+    done
+
+    if [ "$healthy" = true ]; then
+        echo -e "    ${GREEN}✓ p${slot} backend healthy (${waited}s)${NC}"
     else
-        echo -e "    ${YELLOW}⚠  p${slot} backend may not have started${NC}"
+        echo -e "    ${YELLOW}⚠  p${slot} backend did not become healthy within 150s${NC}"
         echo -e "    Check: ssh ${ZERO_USER}@${ip} 'journalctl -u mealplanner -n 50'"
     fi
 }
 
 deploy_zeros() {
-    if [ ! -d "backend/dist" ]; then
-        echo -e "${RED}❌ backend/dist not found — run 'npm run build' in backend/ first${NC}"
+    # Rebuild locally (on the Pi 4B's arm64 host, not in a container) before
+    # every Zero W deploy, rather than trusting whatever backend/dist and
+    # generated Prisma client happen to be sitting around — those previously
+    # went stale for a month (last built 2026-07-01) with nothing to catch
+    # it, so every deploy in between silently shipped pre-fix code. This also
+    # generates the Prisma client once on a Prisma-supported architecture;
+    # see the matching comment in deploy_to_zero() for why that matters.
+    echo -e "${BLUE}Building backend locally before Zero W deploy...${NC}"
+
+    # The Pi 4B host itself only runs the backend via container — it never
+    # had a native Node.js/pnpm install. arm64 is officially supported by
+    # Node (unlike the Zero Ws' armv6), so no unofficial-builds workaround
+    # needed here, just the standard nodejs.org distribution.
+    if ! command -v node >/dev/null 2>&1 || ! node --version | grep -qE "^v${NODE_VERSION//./\\.}"; then
+        echo -e "${BLUE}Installing Node.js ${NODE_VERSION} (arm64) on the Pi 4B host...${NC}"
+        local pi4_node_tar="/tmp/node-${NODE_VERSION}-linux-arm64.tar.xz"
+        curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-arm64.tar.xz" \
+            -o "$pi4_node_tar"
+        sudo tar -xJf "$pi4_node_tar" -C /usr/local --strip-components=1
+        rm -f "$pi4_node_tar"
+    fi
+    command -v pnpm >/dev/null 2>&1 || (sudo corepack enable && sudo corepack prepare pnpm@11.1.2 --activate)
+
+    if ! (cd backend && pnpm install --frozen-lockfile && pnpm run build); then
+        echo -e "${RED}❌ Local backend build failed — see output above${NC}"
+        return 1
+    fi
+    echo -e "${GREEN}✓ backend/dist and Prisma client are current${NC}"
+
+    # Locate the generated client's pnpm virtual-store directory (something
+    # like .pnpm/@prisma+client@7.9.1_.../) by resolving the @prisma/client
+    # symlink rather than hardcoding the version/hash — pnpm names this
+    # deterministically from the frozen lockfile, so the same path exists
+    # once each Zero W runs its own install from the identical lockfile.
+    PRISMA_PNPM_DIR=$(realpath backend/node_modules/@prisma/client | grep -oE '\.pnpm/[^/]+')
+    if [ -z "$PRISMA_PNPM_DIR" ]; then
+        echo -e "${RED}❌ Could not resolve generated Prisma client's pnpm store path${NC}"
         return 1
     fi
 

--- a/scripts/pi-run.sh
+++ b/scripts/pi-run.sh
@@ -304,7 +304,9 @@ deploy_zeros() {
         echo ""
     done
 
-    [ "$any_failed" = true ] && echo -e "${YELLOW}⚠  One or more Zero W deployments failed — check output above${NC}"
+    if [ "$any_failed" = true ]; then
+        echo -e "${YELLOW}⚠  One or more Zero W deployments failed — check output above${NC}"
+    fi
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
\`deploy_zeros()\`'s final line, \`[ "\$any_failed" = true ] && echo ...\`, returns exit 1 as a bare statement whenever \`any_failed\` is false — under \`set -e\` this aborted the script before \`--zeros-only\`'s \`exit 0\` ever ran, so \`pi-run.sh\` reported failure even when every node deployed successfully.

Pre-existing bug, not introduced by the last two Zero W fixes (#358 and its predecessor) — just never observable before, since no prior deploy had ever gotten all 4 nodes healthy to reach this line with \`any_failed\` still false.

## Test plan
- [x] Confirmed live on real hardware: reverting to the bare \`&&\` made \`pi-run.sh --zeros-only\` exit 1 despite all 4 Zero W nodes reporting healthy in its own output; wrapping in \`if\`/\`fi\` made the identical run exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)