### PR TITLE
feat(recipes): lightweight line-by-line ingredient entry for staples

### DIFF
--- a/backend/src/controllers/recipe.controller.ts
+++ b/backend/src/controllers/recipe.controller.ts
@@ -70,10 +70,7 @@ function getUserId(req: Request): string | undefined {
 /**
  * Helper function to verify recipe ownership
  */
-async function verifyRecipeOwnership(
-  recipeId: string,
-  userId: string
-): Promise<void> {
+async function verifyRecipeOwnership(recipeId: string, userId: string) {
   const recipe = await prisma.recipe.findUnique({
     where: { id: recipeId },
   });
@@ -85,6 +82,8 @@ async function verifyRecipeOwnership(
   if (recipe.userId !== userId) {
     throw new AppError('Access denied', 403);
   }
+
+  return recipe;
 }
 
 /**
@@ -351,12 +350,16 @@ export async function getRecipeById(
  * Create new recipe
 /**
  * Helper function to find or create an ingredient
+ *
+ * Returns the ingredient's own default unit alongside its id so callers can
+ * fall back to it when a RecipeIngredient line omits a unit (quick ingredient
+ * entry, issue #328 — no required quantity/unit on that path).
  */
 async function findOrCreateIngredient(
   ingredientId: string | undefined,
   ingredientName: string,
-  unit: string
-): Promise<string> {
+  unit: string | undefined
+): Promise<{ id: string; unit: string }> {
   // Validate ingredient name
   if (!ingredientName || typeof ingredientName !== 'string' || ingredientName.trim() === '') {
     throw new AppError('Ingredient name is required and must be a non-empty string', 400);
@@ -369,11 +372,11 @@ async function findOrCreateIngredient(
     const existingIngredient = await prisma.ingredient.findUnique({
       where: { id: ingredientId },
     });
-    
+
     if (existingIngredient) {
-      return ingredientId;
+      return { id: existingIngredient.id, unit: existingIngredient.unit };
     }
-    
+
     // If ID provided but doesn't exist, log warning and fall through to create/find by name
     logger.warn(`Ingredient ID ${ingredientId} not found, searching by name: ${trimmedName}`);
   }
@@ -398,7 +401,7 @@ async function findOrCreateIngredient(
     });
   }
 
-  return ingredient.id;
+  return { id: ingredient.id, unit: ingredient.unit };
 }
 
 export async function createRecipe(
@@ -477,18 +480,20 @@ export async function createRecipe(
     // Handle ingredients - create new ones if needed
     if (ingredients && ingredients.length > 0) {
       for (const ing of ingredients) {
-        const ingredientId = await findOrCreateIngredient(
+        const ingredient = await findOrCreateIngredient(
           ing.ingredientId,
           ing.ingredientName,
           ing.unit
         );
 
+        // Quick-added ingredient lines (issue #328) may omit quantity/unit;
+        // fall back to a placeholder quantity and the ingredient's own unit.
         await prisma.recipeIngredient.create({
           data: {
             recipeId: recipe.id,
-            ingredientId,
-            quantity: ing.quantity,
-            unit: ing.unit,
+            ingredientId: ingredient.id,
+            quantity: ing.quantity ?? 1,
+            unit: ing.unit || ingredient.unit,
             notes: ing.notes || null,
             isOptional: ing.isOptional || false,
           },
@@ -535,7 +540,7 @@ export async function updateRecipe(
     }
 
     // Check if recipe exists and user owns it
-    await verifyRecipeOwnership(id, userId);
+    const existingRecipe = await verifyRecipeOwnership(id, userId);
 
     const {
       title,
@@ -554,14 +559,17 @@ export async function updateRecipe(
       ingredients,
     } = req.body;
 
-    // Calculate cleanup score if relevant fields are being updated
+    // Calculate cleanup score if relevant fields are being updated. Partial
+    // updates (e.g. quick ingredient entry, issue #328, which sends only
+    // `ingredients`) omit the rest, so fall back to the recipe's current
+    // stored values rather than passing undefined into the calculation.
     let cleanupScore;
     if (ingredients || instructions || prepTime || cookTime) {
       cleanupScore = calculateCleanupScore({
         ingredients: ingredients || [],
-        instructions,
-        cookTime,
-        prepTime,
+        instructions: instructions ?? existingRecipe.instructions,
+        cookTime: cookTime ?? existingRecipe.cookTime,
+        prepTime: prepTime ?? existingRecipe.prepTime,
       });
     }
 
@@ -596,18 +604,20 @@ export async function updateRecipe(
 
       // Add new ingredients
       for (const ing of ingredients) {
-        const ingredientId = await findOrCreateIngredient(
+        const ingredient = await findOrCreateIngredient(
           ing.ingredientId,
           ing.ingredientName || ing.name,
           ing.unit
         );
 
+        // Quick-added ingredient lines (issue #328) may omit quantity/unit;
+        // fall back to a placeholder quantity and the ingredient's own unit.
         await prisma.recipeIngredient.create({
           data: {
             recipeId: id,
-            ingredientId,
-            quantity: ing.quantity,
-            unit: ing.unit,
+            ingredientId: ingredient.id,
+            quantity: ing.quantity ?? 1,
+            unit: ing.unit || ingredient.unit,
             notes: ing.notes || null,
             isOptional: ing.isOptional || false,
           },

--- a/frontend/src/__tests__/store/recipesSlice.test.ts
+++ b/frontend/src/__tests__/store/recipesSlice.test.ts
@@ -147,12 +147,14 @@ describe('recipesSlice', () => {
   });
 
   describe('updateRecipe thunk', () => {
+    // PUT /api/recipes/:id responds with { message, recipe }, not the
+    // recipe directly -- the fulfilled payload mirrors that shape.
     it('updates recipe in list', () => {
       const existing = { ...initialState, recipes: [mockRecipe] };
       const updated = { ...mockRecipe, title: 'Updated Pasta' };
       const state = recipesReducer(
         existing,
-        updateRecipe.fulfilled(updated, '', { id: 'recipe-1', data: {} })
+        updateRecipe.fulfilled({ message: 'Recipe updated successfully', recipe: updated }, '', { id: 'recipe-1', data: {} })
       );
       expect(state.recipes[0].title).toBe('Updated Pasta');
     });
@@ -162,7 +164,7 @@ describe('recipesSlice', () => {
       const updated = { ...mockRecipe, title: 'Updated' };
       const state = recipesReducer(
         existing,
-        updateRecipe.fulfilled(updated, '', { id: 'recipe-1', data: {} })
+        updateRecipe.fulfilled({ message: 'Recipe updated successfully', recipe: updated }, '', { id: 'recipe-1', data: {} })
       );
       expect(state.currentRecipe?.title).toBe('Updated');
     });

--- a/frontend/src/components/QuickIngredientEntryDialog.tsx
+++ b/frontend/src/components/QuickIngredientEntryDialog.tsx
@@ -1,0 +1,280 @@
+/**
+ * Copyright (c) 2026 e2kd7n
+ * All rights reserved.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  IconButton,
+  TextField,
+  Autocomplete,
+  Stack,
+  Box,
+  Typography,
+  Alert,
+  Link,
+  CircularProgress,
+} from '@mui/material';
+import { Close as CloseIcon, DragIndicator as DragIndicatorIcon } from '@mui/icons-material';
+import { useNavigate } from 'react-router-dom';
+import { useAppDispatch } from '../store/hooks';
+import { updateRecipe } from '../store/slices/recipesSlice';
+import { getApiErrorMessage } from '../utils/errorHandler';
+import api from '../services/api';
+
+interface IngredientOption {
+  id: string;
+  name: string;
+  category: string;
+  unit: string;
+}
+
+interface IngredientRow {
+  rowId: string;
+  text: string;
+  selected: IngredientOption | null;
+}
+
+let rowIdCounter = 0;
+const newRow = (text = ''): IngredientRow => ({ rowId: `row-${++rowIdCounter}`, text, selected: null });
+
+interface QuickIngredientEntryDialogProps {
+  open: boolean;
+  recipe: { id: string; title: string } | null;
+  onClose: () => void;
+}
+
+/**
+ * Lightweight, line-by-line ingredient entry for quick-added staple recipes
+ * (issue #328). Deliberately not the CreateRecipe wizard: no quantity/unit
+ * fields, no instruction-step gate — every line still resolves to a real
+ * RecipeIngredient row server-side (backend defaults quantity/unit when
+ * omitted), never a freeform text blob.
+ */
+const QuickIngredientEntryDialog: React.FC<QuickIngredientEntryDialogProps> = ({
+  open,
+  recipe,
+  onClose,
+}) => {
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+  const [rows, setRows] = useState<IngredientRow[]>([newRow()]);
+  const [optionsByRow, setOptionsByRow] = useState<Record<string, IngredientOption[]>>({});
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const debounceRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+
+  useEffect(() => {
+    if (open) {
+      setRows([newRow()]);
+      setOptionsByRow({});
+      setError('');
+    }
+  }, [open, recipe?.id]);
+
+  const fetchSuggestions = useCallback(async (rowId: string, text: string) => {
+    if (text.trim().length < 2) {
+      setOptionsByRow((prev) => ({ ...prev, [rowId]: [] }));
+      return;
+    }
+    try {
+      const response = await api.get('/ingredients/search/suggestions', {
+        params: { q: text.trim(), limit: 8 },
+      });
+      setOptionsByRow((prev) => ({ ...prev, [rowId]: response.data?.data || [] }));
+    } catch {
+      setOptionsByRow((prev) => ({ ...prev, [rowId]: [] }));
+    }
+  }, []);
+
+  const handleRowTextChange = (rowId: string, text: string) => {
+    setRows((prev) => prev.map((r) => (r.rowId === rowId ? { ...r, text, selected: null } : r)));
+
+    if (debounceRef.current[rowId]) clearTimeout(debounceRef.current[rowId]);
+    debounceRef.current[rowId] = setTimeout(() => fetchSuggestions(rowId, text), 300);
+  };
+
+  const handleRowSelect = (rowId: string, option: IngredientOption | null) => {
+    setRows((prev) =>
+      prev.map((r) => (r.rowId === rowId ? { ...r, text: option?.name || r.text, selected: option } : r))
+    );
+  };
+
+  const insertLinesAfter = (rowId: string, lines: string[]) => {
+    const trimmed = lines.map((l) => l.trim()).filter(Boolean);
+    if (trimmed.length === 0) return;
+
+    setRows((prev) => {
+      const index = prev.findIndex((r) => r.rowId === rowId);
+      const updated = [...prev];
+      updated[index] = { ...updated[index], text: trimmed[0], selected: null };
+      const newRows = trimmed.slice(1).map((line) => newRow(line));
+      updated.splice(index + 1, 0, ...newRows);
+      return updated;
+    });
+  };
+
+  const handlePaste = (rowId: string, event: React.ClipboardEvent<HTMLDivElement>) => {
+    const pasted = event.clipboardData.getData('text');
+    if (pasted.includes('\n')) {
+      event.preventDefault();
+      insertLinesAfter(rowId, pasted.split('\n'));
+    }
+  };
+
+  const handleEnter = (rowId: string) => {
+    const index = rows.findIndex((r) => r.rowId === rowId);
+    const isLast = index === rows.length - 1;
+    if (isLast && rows[index].text.trim()) {
+      setRows((prev) => [...prev, newRow()]);
+    }
+  };
+
+  const handleRemoveRow = (rowId: string) => {
+    setRows((prev) => (prev.length === 1 ? [newRow()] : prev.filter((r) => r.rowId !== rowId)));
+  };
+
+  const handleSave = async () => {
+    if (!recipe) return;
+
+    const ingredients = rows
+      .filter((r) => r.text.trim())
+      .map((r) => ({
+        ingredientId: r.selected?.id,
+        ingredientName: r.selected?.name || r.text.trim(),
+      }));
+
+    if (ingredients.length === 0) {
+      setError('Add at least one ingredient, or close this dialog to add them later.');
+      return;
+    }
+
+    setSaving(true);
+    setError('');
+    try {
+      await dispatch(updateRecipe({ id: recipe.id, data: { ingredients } })).unwrap();
+      onClose();
+    } catch (err: unknown) {
+      setError(getApiErrorMessage(err, 'Failed to save ingredients'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleOpenFullEditor = () => {
+    if (!recipe) return;
+    onClose();
+    navigate(`/recipes/${recipe.id}/edit`);
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+        <Stack spacing={0.5}>
+          <Typography variant="h6" component="span">
+            Add ingredients{recipe ? ` to "${recipe.title}"` : ''}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            So this shows up in your grocery list
+          </Typography>
+        </Stack>
+        <IconButton onClick={onClose} aria-label="Close" size="small">
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError('')}>
+            {error}
+          </Alert>
+        )}
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Type or paste one ingredient per line. No quantities or units needed — just get them on the list.
+        </Typography>
+        <Stack spacing={1.5}>
+          {rows.map((row, index) => {
+            const isNew = row.text.trim().length > 0 && !row.selected;
+            return (
+              <Box key={row.rowId} sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
+                <DragIndicatorIcon fontSize="small" sx={{ color: 'text.disabled', mt: 1.5 }} />
+                <Stack sx={{ flexGrow: 1 }}>
+                  <Autocomplete
+                    freeSolo
+                    options={optionsByRow[row.rowId] || []}
+                    getOptionLabel={(option) => (typeof option === 'string' ? option : option.name)}
+                    filterOptions={(options) => options}
+                    inputValue={row.text}
+                    onInputChange={(_, value, reason) => {
+                      if (reason === 'input') handleRowTextChange(row.rowId, value);
+                    }}
+                    onChange={(_, value) => {
+                      if (value && typeof value !== 'string') handleRowSelect(row.rowId, value);
+                    }}
+                    renderInput={(params) => (
+                      <TextField
+                        {...params}
+                        autoFocus={index === rows.length - 1 && index > 0}
+                        placeholder={`Ingredient ${index + 1} (e.g. ground beef)`}
+                        size="small"
+                        onPaste={(e) => handlePaste(row.rowId, e)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            e.preventDefault();
+                            handleEnter(row.rowId);
+                          }
+                        }}
+                      />
+                    )}
+                  />
+                  {isNew && (
+                    <Typography variant="caption" color="primary.main" sx={{ ml: 1.5, mt: 0.25 }}>
+                      Will create "{row.text.trim()}" as a new ingredient
+                    </Typography>
+                  )}
+                </Stack>
+                <IconButton
+                  size="small"
+                  onClick={() => handleRemoveRow(row.rowId)}
+                  aria-label={`Remove ingredient line ${index + 1}`}
+                  sx={{ mt: 0.5 }}
+                >
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+              </Box>
+            );
+          })}
+        </Stack>
+        <Button
+          size="small"
+          onClick={() => setRows((prev) => [...prev, newRow()])}
+          sx={{ mt: 1.5 }}
+        >
+          + Add line
+        </Button>
+        <Typography variant="body2" sx={{ mt: 3 }}>
+          Want to add times, steps, or a photo too?{' '}
+          <Link component="button" variant="body2" onClick={handleOpenFullEditor}>
+            Open the full recipe editor
+          </Link>
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={saving}>
+          Cancel
+        </Button>
+        <Button onClick={handleSave} variant="contained" disabled={saving}>
+          {saving ? <CircularProgress size={20} /> : 'Save ingredients'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default QuickIngredientEntryDialog;
+
+// Made with Bob

--- a/frontend/src/pages/Recipes.tsx
+++ b/frontend/src/pages/Recipes.tsx
@@ -57,6 +57,7 @@ import { useDebounce } from '../hooks/useDebounce';
 import { useCachedImage } from '../hooks/useCachedImage';
 import BrowseRecipes from './BrowseRecipes';
 import RecipeDiscoveryEmptyState from '../components/RecipeDiscoveryEmptyState';
+import QuickIngredientEntryDialog from '../components/QuickIngredientEntryDialog';
 
 // Memoized Recipe Card Component for better performance
 interface RecipeCardProps {
@@ -287,7 +288,15 @@ const Recipes: React.FC = () => {
   }, []);
 
   const handleNavigate = useCallback((id: string) => navigate(`/recipes/${id}`), [navigate]);
-  const handleEditIngredients = useCallback((id: string) => navigate(`/recipes/${id}/edit`), [navigate]);
+
+  // Quick ingredient entry (issue #328) — lightweight line-by-line dialog,
+  // not a navigation to the full CreateRecipe wizard.
+  const [ingredientDialogRecipeId, setIngredientDialogRecipeId] = useState<string | null>(null);
+  const handleEditIngredients = useCallback((id: string) => setIngredientDialogRecipeId(id), []);
+  const ingredientDialogRecipe = useMemo(
+    () => recipes.find((r) => r.id === ingredientDialogRecipeId) || null,
+    [recipes, ingredientDialogRecipeId]
+  );
 
   const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => setActiveTab(newValue);
 
@@ -595,6 +604,12 @@ const Recipes: React.FC = () => {
           <BrowseRecipes />
         </Box>
       </Box>
+
+      <QuickIngredientEntryDialog
+        open={ingredientDialogRecipeId !== null}
+        recipe={ingredientDialogRecipe}
+        onClose={() => setIngredientDialogRecipeId(null)}
+      />
     </Container>
   );
 };

--- a/frontend/src/store/slices/recipesSlice.ts
+++ b/frontend/src/store/slices/recipesSlice.ts
@@ -252,12 +252,15 @@ const recipesSlice = createSlice({
       })
       // Update recipe
       .addCase(updateRecipe.fulfilled, (state, action) => {
-        const index = state.recipes.findIndex(r => r.id === action.payload.id);
+        // PUT /api/recipes/:id responds with { message, recipe }, not the
+        // recipe directly — unwrap it before matching against state.recipes.
+        const updated = action.payload.recipe;
+        const index = state.recipes.findIndex(r => r.id === updated.id);
         if (index !== -1) {
-          state.recipes[index] = action.payload;
+          state.recipes[index] = updated;
         }
-        if (state.currentRecipe?.id === action.payload.id) {
-          state.currentRecipe = action.payload;
+        if (state.currentRecipe?.id === updated.id) {
+          state.currentRecipe = updated;
         }
       })
       // Delete recipe


### PR DESCRIPTION
## Summary
- Closes out the last piece of #328. The quick-add-to-meal-plan flow and the "Needs Ingredients" filter on the Recipes page already shipped in ac1a5fa; "Add ingredients" still routed to the full CreateRecipe wizard, which gates on requiring an instruction step — not the lightweight experience the issue asked for.
- New `QuickIngredientEntryDialog`, opened inline from the Recipes page: type-or-paste one ingredient per line, soft-matched against the ingredient catalog, with an inline "Will create '<name>' as a new ingredient" hint when there's no match. Enter appends a line; pasting multi-line text splits across rows. A de-emphasized link still covers the full recipe editor for anyone who wants times/steps/photos.
- Backend defaults `quantity`/`unit` when a line omits them, so a bare ingredient name is enough to save.
- Fixes two bugs found while building/testing this: `updateRecipe.fulfilled` wasn't unwrapping the API response shape (so the recipe list never updated after a save), and `updateRecipe`'s cleanup-score recalculation crashed on any partial update that sends `ingredients` without `instructions` (exactly this dialog's request shape).

## Test plan
- [x] `tsc --noEmit` clean on backend, `npm run build` clean on frontend
- [x] Lint clean on both (no new warnings/errors)
- [x] Verified end-to-end against a throwaway Postgres container: registered a user, quick-added a staple meal, drove the dialog through typing, paste-splitting, and saving; confirmed in Postgres that ingredients persisted with expected defaults (`quantity=1.00`, `unit='unit'`) and the "Needs ingredients" chip updated live in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)