### PR TITLE
fix(security): close ingredient/recipe auth-bypass bugs, throttle visual login

### DIFF
--- a/backend/src/routes/ingredient.routes.ts
+++ b/backend/src/routes/ingredient.routes.ts
@@ -5,7 +5,7 @@
 
 
 import { Router } from 'express';
-import { authenticate, optionalAuthenticate } from '../middleware/auth';
+import { authenticate } from '../middleware/auth';
 import { requireAdmin } from '../middleware/admin';
 import {
   getIngredients,
@@ -61,7 +61,7 @@ router.get('/:id', getIngredientById);
  * @desc    Create new ingredient (checks for similar ingredients unless force=true)
  * @access  Private (Admin only in production)
  */
-router.post('/', optionalAuthenticate, createIngredient);
+router.post('/', authenticate, requireAdmin, createIngredient);
 
 /**
  * @route   POST /api/ingredients/merge
@@ -75,14 +75,14 @@ router.post('/merge', authenticate, requireAdmin, mergeIngredients);
  * @desc    Update ingredient
  * @access  Private (Admin only in production)
  */
-router.put('/:id', optionalAuthenticate, updateIngredient);
+router.put('/:id', authenticate, requireAdmin, updateIngredient);
 
 /**
  * @route   DELETE /api/ingredients/:id
  * @desc    Delete ingredient
  * @access  Private (Admin only in production)
  */
-router.delete('/:id', optionalAuthenticate, deleteIngredient);
+router.delete('/:id', authenticate, requireAdmin, deleteIngredient);
 
 export default router;
 

--- a/backend/src/routes/recipe.routes.ts
+++ b/backend/src/routes/recipe.routes.ts
@@ -5,7 +5,7 @@
 
 
 import { Router } from 'express';
-import { authenticate, optionalAuthenticate } from '../middleware/auth';
+import { authenticate } from '../middleware/auth';
 import {
   getRecipes,
   getRecipeById,
@@ -23,9 +23,9 @@ const router: Router = Router();
 /**
  * @route   GET /api/recipes/search
  * @desc    Search recipes with advanced filters
- * @access  Public/Private
+ * @access  Private
  */
-router.get('/search', optionalAuthenticate, searchRecipes);
+router.get('/search', authenticate, searchRecipes);
 
 /**
  * @route   POST /api/recipes/import
@@ -37,16 +37,16 @@ router.post('/import', authenticate, importRecipe);
 /**
  * @route   GET /api/recipes
  * @desc    Get all recipes
- * @access  Public/Private
+ * @access  Private
  */
-router.get('/', optionalAuthenticate, getRecipes);
+router.get('/', authenticate, getRecipes);
 
 /**
  * @route   GET /api/recipes/:id
  * @desc    Get recipe by ID
- * @access  Public/Private
+ * @access  Private
  */
-router.get('/:id', optionalAuthenticate, getRecipeById);
+router.get('/:id', authenticate, getRecipeById);
 
 /**
  * @route   POST /api/recipes

--- a/backend/src/routes/visualAuth.routes.ts
+++ b/backend/src/routes/visualAuth.routes.ts
@@ -5,6 +5,7 @@
 
 import { Router } from 'express';
 import { authenticate } from '../middleware/auth';
+import { authRateLimiter } from '../middleware/rateLimiter';
 import {
   listUsers,
   getVisualChallenge,
@@ -21,12 +22,16 @@ import {
 const router: Router = Router();
 
 // ── Public endpoints (no auth required — local network convenience) ────────
-router.get('/users', listUsers);
-router.get('/visual-challenge/:userId', getVisualChallenge);
-router.post('/login/visual', visualLogin);
-router.post('/login/device', deviceLogin);
+// authRateLimiter (5 attempts/15 min in production) applies to all of these:
+// the visual-password challenge/response is a low-entropy factor (1-of-4, or
+// 1-of-8 for stock images) that's otherwise trivially brute-forceable without
+// throttling — see the security audit that added this.
+router.get('/users', authRateLimiter, listUsers);
+router.get('/visual-challenge/:userId', authRateLimiter, getVisualChallenge);
+router.post('/login/visual', authRateLimiter, visualLogin);
+router.post('/login/device', authRateLimiter, deviceLogin);
 router.post('/logout/device', deviceLogout);
-router.get('/visual-setup/stock-images', getStockImages);
+router.get('/visual-setup/stock-images', authRateLimiter, getStockImages);
 
 // ── Authenticated endpoints ───────────────────────────────────────────────
 router.get('/visual-password/status', authenticate, getVisualPasswordStatus);


### PR DESCRIPTION
## Summary

Fixes from a full-codebase + live-pi4 security audit (code scan + read-only production recon, requested directly rather than tied to an existing issue).

- **HIGH** — `POST/PUT/DELETE /api/ingredients` used `optionalAuthenticate` despite doc comments saying "Admin only in production" — any anonymous caller could create/edit/delete shared catalog ingredients, including stripping allergen data. Now `authenticate, requireAdmin`, matching the existing `/merge` endpoint.
- **HIGH** — `GET /api/recipes`, `/search`, `/:id` used `optionalAuthenticate` — with zero login, a caller got every recipe from every account on the instance, not just the intended single-household sharing model. Now `authenticate`. Verified no frontend flow relies on anonymous access (everything recipe-related sits behind `PrivateRoute`).
- **HIGH** — Visual-login challenge/response endpoints had no rate limiting. `GET /visual-challenge/:userId` hands back the correct answer among 3-4 candidates to anyone who knows a `memberId` (itself available via unauthenticated `GET /users`); `POST /login/visual` issues a full JWT + 14-day device cookie on a match with no attempt cap — a ~1-in-4 (1-in-8 for stock images) guess from full account takeover. Applied the existing `authRateLimiter` (5 attempts/15min prod) already used on password login.

`tsc`, `eslint`, and the production build all pass clean on the changed files.

## Not included in this PR (flagged, not fixed)

- **LOW** — backend container runs as root (no `USER` directive in the Dockerfile). Left out deliberately: the multi-stage arm64 build is already fragile (see the `#290`-referenced comments throughout `backend/Dockerfile`), I can't test-build it locally in this environment, and it's defense-in-depth only, not an active exploit. Worth a dedicated, CI-verified follow-up PR.
- The visual-login feature's deeper design limitation (the challenge endpoint structurally can't avoid revealing the answer set without a bigger redesign) is now rate-limited but not eliminated — flagging as a longer-term item if a human wants to revisit the auth model, not fixing further here.
- Live pi4 findings (no firewall, SSH password auth enabled, root SSH login permitted, Postgres/Redis reachable beyond the intended cluster-only network segment) are being reported separately — those need explicit sign-off before any change, given lockout/outage risk on a remote single-board production host.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [x] `npm run build` (full backend `tsc` build) clean
- [ ] Manual verification that legitimate logged-in flows for recipes/ingredients/visual-login still work end-to-end (not run — no local dev server exercised in this pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)