### PR TITLE
fix: MemberWelcome test ThemeProvider, e2e locator flake, secret newline bug

### DIFF
--- a/frontend/e2e/tests/recipes/create.spec.ts
+++ b/frontend/e2e/tests/recipes/create.spec.ts
@@ -62,8 +62,10 @@ test.describe('Create Recipe', () => {
     // to advance past step 1.
     await authenticatedPage.getByRole('button', { name: /^next$/i }).click();
 
-    // Should show validation error and stay on step 1
-    await expect(authenticatedPage.getByText(/recipe title is required/i)).toBeVisible();
+    // Should show validation error and stay on step 1. The message renders twice
+    // (summary Alert + field FormHelperText), so scope to the Alert to avoid a
+    // Playwright strict-mode ambiguous match (#372).
+    await expect(authenticatedPage.getByRole('alert').getByText(/recipe title is required/i)).toBeVisible();
     await expect(authenticatedPage.getByLabel(/recipe title/i)).toBeVisible();
   });
 

--- a/frontend/src/__tests__/pages/MemberWelcome.test.tsx
+++ b/frontend/src/__tests__/pages/MemberWelcome.test.tsx
@@ -4,8 +4,10 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
+import { ThemeProvider } from '@mui/material/styles';
 import { configureStore } from '@reduxjs/toolkit';
 import authReducer from '../../store/slices/authSlice';
+import { theme } from '../../theme';
 import MemberWelcome from '../../pages/MemberWelcome';
 
 const mockNavigate = vi.fn();
@@ -39,9 +41,11 @@ function createStore(authState = {}) {
 function renderMemberWelcome(authState = {}) {
   return render(
     <Provider store={createStore(authState)}>
-      <MemoryRouter initialEntries={['/member-welcome']}>
-        <MemberWelcome />
-      </MemoryRouter>
+      <ThemeProvider theme={theme}>
+        <MemoryRouter initialEntries={['/member-welcome']}>
+          <MemberWelcome />
+        </MemoryRouter>
+      </ThemeProvider>
     </Provider>
   );
 }

--- a/scripts/generate-secrets.sh
+++ b/scripts/generate-secrets.sh
@@ -41,12 +41,12 @@ trap 'rm -f "$ROTATION_MANIFEST"' EXIT
 # Function to generate a secure random password
 generate_password() {
     local length=${1:-32}
-    openssl rand -base64 48 | tr -d "=+/" | cut -c1-${length}
+    openssl rand -base64 48 | tr -d "\n=+/" | cut -c1-${length}
 }
 
 # Function to generate a secure JWT secret (longer)
 generate_jwt_secret() {
-    openssl rand -base64 64 | tr -d "=+/" | cut -c1-64
+    openssl rand -base64 64 | tr -d "\n=+/" | cut -c1-64
 }
 
 # Function to generate secret with metadata and checksum
@@ -57,8 +57,12 @@ generate_secret_with_metadata() {
     
     echo -e "${BLUE}Generating ${name}...${NC}"
     
-    # Generate the secret
-    local secret=$(openssl rand -base64 $((length * 2)) | tr -d "=+/" | cut -c1-${length})
+    # Generate the secret. openssl rand -base64 wraps output at 64 chars/line for
+    # anything longer than that, and `cut -c1-N` truncates per line rather than
+    # across the whole stream — without stripping newlines first, the embedded
+    # line breaks survive into the secret (and broke DATABASE_URL on rotation,
+    # see #364). Strip them before cut so the truncation is on one continuous line.
+    local secret=$(openssl rand -base64 $((length * 2)) | tr -d "\n=+/" | cut -c1-${length})
     
     # Write secret to file
     echo -n "$secret" > "$SECRETS_DIR/${name}.txt"


### PR DESCRIPTION
## Summary
- Fixes #371 — `MemberWelcome.test.tsx` render helper now wraps in `ThemeProvider`, so `useTheme()` resolves the app theme (with `palette.custom`) instead of MUI's default.
- Fixes #372 — scopes the e2e "recipe title is required" assertion to the summary `Alert` (`role="alert"`) since the message also renders in the field's `FormHelperText`, causing a Playwright strict-mode ambiguous match.
- Fixes #364 (root cause) — `generate-secrets.sh` no longer embeds literal newlines into generated secrets. `openssl rand -base64` wraps at 64 chars/line once output exceeds that length, and `cut -c1-N` truncates per line rather than across the stream, so line breaks were surviving into the secret value. Confirmed live on the Pi: attempting to establish the `SECRET_ROTATION_STATUS.json` baseline via `rotate-secrets-if-due.sh --force` rotated `postgres_password` to a value containing an embedded newline, corrupting `DATABASE_URL` and failing the post-rotation backend health check. The script's own rollback safety net worked correctly — old secrets were restored, app came back healthy, no outage.

## Test plan
- [x] `npx vitest run src/__tests__/pages/MemberWelcome.test.tsx` — 11/11 passing (was crashing on every test)
- [x] `npx eslint` on both changed frontend files — clean
- [x] `bash -n scripts/generate-secrets.sh` — syntax OK
- [x] Reproduced the openssl line-wrap bug on the Pi against scratch (non-secret) data and verified the `tr -d "\n=+/"` fix produces correctly-sized, single-line output
- [ ] After merge: pull on the Pi and re-run `./scripts/rotate-secrets-if-due.sh --force` to actually establish the rotation baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)